### PR TITLE
Adds deserialize_public_key_cached

### DIFF
--- a/crates/bls-crypto/src/bls/cache.rs
+++ b/crates/bls-crypto/src/bls/cache.rs
@@ -31,7 +31,7 @@ impl PublicKeyCache {
         Self {
             keys: HashSet::new(),
             combined: PublicKey(G2Projective::zero()),
-            de: LruCache::new(128),
+            de: LruCache::new(512),
         }
     }
 

--- a/crates/bls-snark-sys/src/cache.rs
+++ b/crates/bls-snark-sys/src/cache.rs
@@ -1,0 +1,6 @@
+use crate::PublicKeyCache;
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+
+pub static PUBLIC_KEY_CACHE: Lazy<Mutex<PublicKeyCache>> =
+    Lazy::new(|| Mutex::new(PublicKeyCache::new()));

--- a/crates/bls-snark-sys/src/lib.rs
+++ b/crates/bls-snark-sys/src/lib.rs
@@ -11,6 +11,7 @@ use bls_crypto::hash_to_curve::try_and_increment::{COMPOSITE_HASH_TO_G1, DIRECT_
 use core::fmt::Display;
 use once_cell::sync::Lazy;
 
+pub(crate) mod cache;
 pub mod serialization;
 pub mod signatures;
 pub mod snark;

--- a/crates/bls-snark-sys/src/signatures.rs
+++ b/crates/bls-snark-sys/src/signatures.rs
@@ -1,17 +1,12 @@
 use crate::{
+    cache::PUBLIC_KEY_CACHE,
     convert_result_to_bool,
     utils::{Message, MessageFFI},
-    PrivateKey, PublicKey, PublicKeyCache, Signature, COMPOSITE_HASH_TO_G1, DIRECT_HASH_TO_G1,
+    PrivateKey, PublicKey, Signature, COMPOSITE_HASH_TO_G1, DIRECT_HASH_TO_G1,
 };
 use algebra::{ProjectiveCurve, ToBytes};
 use bls_crypto::{BLSError, HashToCurve, POP_DOMAIN, SIG_DOMAIN};
 use std::{os::raw::c_int, slice};
-
-use once_cell::sync::Lazy;
-use std::sync::Mutex;
-
-static PUBLIC_KEY_CACHE: Lazy<Mutex<PublicKeyCache>> =
-    Lazy::new(|| Mutex::new(PublicKeyCache::new()));
 
 /// # Safety
 ///


### PR DESCRIPTION
### Description

Allows consumers to deserialize public keys while using the LRU cache. Also, enlarges the cache to have a bigger margin.