### PR TITLE
Feature: support padding with dummy epochs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ rust_defaults: &rust_defaults
   <<: *defaults
   docker:
     - image: circleci/rust:latest
-  resource_class: medium+
+  resource_class: large
 
 jobs:
   checkout-repo:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ rust_defaults: &rust_defaults
   <<: *defaults
   docker:
     - image: circleci/rust:latest
-  resource_class: large
+  resource_class: xlarge
 
 jobs:
   checkout-repo:

--- a/crates/bls-gadgets/src/bls.rs
+++ b/crates/bls-gadgets/src/bls.rs
@@ -47,12 +47,22 @@ where
         let _enter = span.enter();
         // Get the message hash and the aggregated public key based on the bitmap
         // and allowed number of non-signers
-        let (prepared_message_hash, prepared_aggregated_pk) = Self::enforce_bitmap_and_prepare(
+        let (message_hash, aggregated_pk) = Self::enforce_bitmap(
             cs.ns(|| "verify partial"),
             pub_keys,
             signed_bitmap,
             message_hash,
             maximum_non_signers,
+        )?;
+
+        let prepared_aggregated_pk = P::prepare_g2(
+            cs.ns(|| "prepare aggregate pk in epoch"),
+            &aggregated_pk,
+        )?;
+
+        let prepared_message_hash = P::prepare_g1(
+            cs.ns(|| "prepare message hash in epoch"),
+            &message_hash,
         )?;
 
         // Prepare the signature and get the generator
@@ -138,7 +148,7 @@ where
         mut cs: CS,
         pub_keys: &[P::G2Gadget],
         signed_bitmap: &[Boolean],
-    ) -> Result<P::G2PreparedGadget, SynthesisError> {
+    ) -> Result<P::G2Gadget, SynthesisError> {
         // Bitmap and Pubkeys must be of the same length
         assert_eq!(signed_bitmap.len(), pub_keys.len());
         // Allocate the G2 Generator
@@ -167,9 +177,7 @@ where
         // Subtract the generator to get the correct aggregate pubkey
         aggregated_pk = aggregated_pk.sub(cs.ns(|| "add neg generator"), &g2_generator)?;
 
-        let prepared_aggregated_pk =
-            P::prepare_g2(cs.ns(|| "prepared aggregated pk"), &aggregated_pk)?;
-        Ok(prepared_aggregated_pk)
+        Ok(aggregated_pk)
     }
 
     /// Returns a gadget which checks that an aggregate pubkey is correctly calculated
@@ -206,23 +214,20 @@ where
     ///
     /// # Panics
     /// If signed_bitmap length != pub_keys length (due to internal call to `enforced_aggregated_pubkeys`)
-    pub fn enforce_bitmap_and_prepare<CS: ConstraintSystem<F>>(
+    pub fn enforce_bitmap<CS: ConstraintSystem<F>>(
         mut cs: CS,
         pub_keys: &[P::G2Gadget],
         signed_bitmap: &[Boolean],
         message_hash: &P::G1Gadget,
         maximum_non_signers: &FpGadget<F>,
-    ) -> Result<(P::G1PreparedGadget, P::G2PreparedGadget), SynthesisError> {
+    ) -> Result<(P::G1Gadget, P::G2Gadget), SynthesisError> {
         trace!("enforcing bitmap");
         enforce_maximum_occurrences_in_bitmap(&mut cs, signed_bitmap, maximum_non_signers, false)?;
 
-        trace!("preparing message hash and aggregated pubkey");
-        let prepared_message_hash =
-            P::prepare_g1(cs.ns(|| "prepared message hash"), &message_hash)?;
-        let prepared_aggregated_pk =
+        let aggregated_pk =
             Self::enforce_aggregated_pubkeys(&mut cs, pub_keys, signed_bitmap)?;
 
-        Ok((prepared_message_hash, prepared_aggregated_pk))
+        Ok((message_hash.clone(), aggregated_pk))
     }
 
     /// Verifying BLS signatures requires preparing a G1 Signature and

--- a/crates/bls-gadgets/src/bls.rs
+++ b/crates/bls-gadgets/src/bls.rs
@@ -55,15 +55,11 @@ where
             maximum_non_signers,
         )?;
 
-        let prepared_aggregated_pk = P::prepare_g2(
-            cs.ns(|| "prepare aggregate pk in epoch"),
-            &aggregated_pk,
-        )?;
+        let prepared_aggregated_pk =
+            P::prepare_g2(cs.ns(|| "prepare aggregate pk in epoch"), &aggregated_pk)?;
 
-        let prepared_message_hash = P::prepare_g1(
-            cs.ns(|| "prepare message hash in epoch"),
-            &message_hash,
-        )?;
+        let prepared_message_hash =
+            P::prepare_g1(cs.ns(|| "prepare message hash in epoch"), &message_hash)?;
 
         // Prepare the signature and get the generator
         let (prepared_signature, prepared_g2_neg_generator) =
@@ -224,8 +220,7 @@ where
         trace!("enforcing bitmap");
         enforce_maximum_occurrences_in_bitmap(&mut cs, signed_bitmap, maximum_non_signers, false)?;
 
-        let aggregated_pk =
-            Self::enforce_aggregated_pubkeys(&mut cs, pub_keys, signed_bitmap)?;
+        let aggregated_pk = Self::enforce_aggregated_pubkeys(&mut cs, pub_keys, signed_bitmap)?;
 
         Ok((message_hash.clone(), aggregated_pk))
     }

--- a/crates/bls-gadgets/src/y_to_bit.rs
+++ b/crates/bls-gadgets/src/y_to_bit.rs
@@ -73,7 +73,7 @@ impl<P: Bls12Parameters> YToBitGadget<P> {
         Ok(y_bit)
     }
 
-    fn is_eq_zero<CS: ConstraintSystem<P::Fp>>(
+    pub fn is_eq_zero<CS: ConstraintSystem<P::Fp>>(
         cs: &mut CS,
         el: &FpGadget<P::Fp>,
     ) -> Result<Boolean, SynthesisError> {

--- a/crates/bls-gadgets/src/y_to_bit.rs
+++ b/crates/bls-gadgets/src/y_to_bit.rs
@@ -81,7 +81,7 @@ impl<P: Bls12Parameters> YToBitGadget<P> {
             Ok(el.get_value().get()? == P::Fp::zero())
         })?;
 
-        // This enforces bit = 1 <=> el != 0.
+        // This enforces bit = 1 <=> el == 0.
         // The idea is that if el is 0, then a constraint of the form `el * el_inv == 1 - result`
         // forces result to be 1. If el is non-zero, then a constraint of the form
         // `el*result == 0` forces result to be 0. inv is set to be 0 in case el is 0 because

--- a/crates/epoch-snark/examples/proof.rs
+++ b/crates/epoch-snark/examples/proof.rs
@@ -51,7 +51,14 @@ fn main() {
 
     // Prover generates the proof given the params
     let time = start_timer!(|| "Generate proof");
-    let proof = prove(&params, num_validators as u32, &first_epoch, &transitions, num_epochs).unwrap();
+    let proof = prove(
+        &params,
+        num_validators as u32,
+        &first_epoch,
+        &transitions,
+        num_epochs,
+    )
+    .unwrap();
     end_timer!(time);
 
     // Verifier checks the proof

--- a/crates/epoch-snark/examples/proof.rs
+++ b/crates/epoch-snark/examples/proof.rs
@@ -51,7 +51,7 @@ fn main() {
 
     // Prover generates the proof given the params
     let time = start_timer!(|| "Generate proof");
-    let proof = prove(&params, num_validators as u32, &first_epoch, &transitions).unwrap();
+    let proof = prove(&params, num_validators as u32, &first_epoch, &transitions, num_epochs).unwrap();
     end_timer!(time);
 
     // Verifier checks the proof

--- a/crates/epoch-snark/src/api/mod.rs
+++ b/crates/epoch-snark/src/api/mod.rs
@@ -10,6 +10,8 @@ pub use verifier::{verify, VerificationError};
 // Instantiate certain types to avoid confusion
 use algebra::{bls12_377, bw6_761};
 pub type BLSCurve = bls12_377::Bls12_377;
+pub type BLSCurveG1 = bls12_377::G1Projective;
+pub type BLSCurveG2 = bls12_377::G2Projective;
 type CPField = bw6_761::Fr;
 pub type CPCurve = bw6_761::BW6_761;
 type CPFrParams = bw6_761::FrParameters;

--- a/crates/epoch-snark/src/api/prover.rs
+++ b/crates/epoch-snark/src/api/prover.rs
@@ -1,4 +1,4 @@
-use super::{setup::Parameters, BLSCurve, BLSCurveG2, CPCurve};
+use super::{setup::Parameters, BLSCurve, BLSCurveG1, BLSCurveG2, CPCurve};
 use algebra::ProjectiveCurve;
 use crate::{epoch_block::{EpochBlock, EpochTransition}, gadgets::{EpochData, HashToBits, HashToBitsHelper, SingleUpdate, ValidatorSetUpdate}};
 use bls_crypto::{
@@ -58,6 +58,9 @@ pub fn prove(
 
     // Generate the BLS proof
     let asig = Signature::aggregate(transitions.iter().map(|epoch| &epoch.aggregate_signature));
+    let mut asig_dummy = (0..max_transitions - num_epochs).map(|_| Signature::from(BLSCurveG1::prime_subgroup_generator())).collect::<Vec<_>>();
+    asig_dummy.push(asig);
+    let asig = Signature::aggregate(&asig_dummy);
 
     let circuit = ValidatorSetUpdate::<BLSCurve> {
         initial_epoch: to_epoch_data(initial_epoch),

--- a/crates/epoch-snark/src/api/prover.rs
+++ b/crates/epoch-snark/src/api/prover.rs
@@ -1,8 +1,6 @@
-use super::{setup::Parameters, BLSCurve, CPCurve};
-use crate::{
-    epoch_block::{EpochBlock, EpochTransition},
-    gadgets::{EpochData, HashToBits, HashToBitsHelper, SingleUpdate, ValidatorSetUpdate},
-};
+use super::{setup::Parameters, BLSCurve, BLSCurveG2, CPCurve};
+use algebra::ProjectiveCurve;
+use crate::{epoch_block::{EpochBlock, EpochTransition}, gadgets::{EpochData, HashToBits, HashToBitsHelper, SingleUpdate, ValidatorSetUpdate}};
 use bls_crypto::{
     hash_to_curve::try_and_increment::COMPOSITE_HASH_TO_G1,
     hashers::{Hasher, COMPOSITE_HASHER},
@@ -24,6 +22,7 @@ pub fn prove(
     num_validators: u32,
     initial_epoch: &EpochBlock,
     transitions: &[EpochTransition],
+    max_transitions: usize,
 ) -> Result<Groth16Proof<CPCurve>, SynthesisError> {
     info!(
         "Generating proof for {} epochs (first epoch: {}, {} validators per epoch)",
@@ -35,10 +34,19 @@ pub fn prove(
     let span = span!(Level::TRACE, "prove");
     let _enter = span.enter();
 
-    let epochs = transitions
+    let mut epochs = transitions
         .iter()
         .map(|transition| to_update(transition))
         .collect::<Vec<_>>();
+
+    let num_epochs = epochs.len();
+    if num_epochs < max_transitions {
+        epochs = [
+            &epochs[..num_epochs-1],
+            &(0..max_transitions - num_epochs).map(|_| to_dummy_update(num_validators)).collect::<Vec<_>>(),
+            &[epochs[num_epochs-1].clone()],
+        ].concat();
+    }
 
     // Generate a helping proof if a Proving Key for the HashToBits
     // circuit was provided
@@ -127,5 +135,16 @@ fn to_update(transition: &EpochTransition) -> SingleUpdate<BLSCurve> {
             .iter()
             .map(|b| Some(*b))
             .collect::<Vec<_>>(),
+    }
+}
+
+fn to_dummy_update(num_validators: u32) -> SingleUpdate<BLSCurve> {
+    SingleUpdate {
+        epoch_data: EpochData {
+            maximum_non_signers: 0,
+            index: Some(0),
+            public_keys: (0..num_validators).map(|_| Some(BLSCurveG2::prime_subgroup_generator())).collect::<Vec<_>>(),
+        },
+        signed_bitmap: (0..num_validators).map(|_| Some(true)).collect::<Vec<_>>(),
     }
 }

--- a/crates/epoch-snark/src/gadgets/epoch_data.rs
+++ b/crates/epoch-snark/src/gadgets/epoch_data.rs
@@ -143,11 +143,13 @@ impl EpochData<Bls12_377> {
         let previous_plus_one =
             previous_index.add_constant(cs.ns(|| "previous plus_one"), &Fr::one())?;
 
-        let index_bit = YToBitGadget::<Parameters>::is_eq_zero(
-            &mut cs.ns(|| "is index zero"),
-            index,
-        )?.not();
-        index.conditional_enforce_equal(cs.ns(|| "index enforce equal"), &previous_plus_one, &index_bit)?;
+        let index_bit =
+            YToBitGadget::<Parameters>::is_eq_zero(&mut cs.ns(|| "is index zero"), index)?.not();
+        index.conditional_enforce_equal(
+            cs.ns(|| "index enforce equal"),
+            &previous_plus_one,
+            &index_bit,
+        )?;
         Ok(())
     }
 

--- a/crates/epoch-snark/src/gadgets/epoch_data.rs
+++ b/crates/epoch-snark/src/gadgets/epoch_data.rs
@@ -3,7 +3,7 @@ use algebra::{
     bw6_761::Fr,
     One, PairingEngine,
 };
-use bls_gadgets::{utils::is_setup, HashToGroupGadget};
+use bls_gadgets::{utils::is_setup, HashToGroupGadget, YToBitGadget};
 use r1cs_core::{ConstraintSystem, SynthesisError};
 use r1cs_std::{
     bls12_377::{G1Gadget, G2Gadget},
@@ -142,7 +142,12 @@ impl EpochData<Bls12_377> {
         trace!("enforcing next epoch");
         let previous_plus_one =
             previous_index.add_constant(cs.ns(|| "previous plus_one"), &Fr::one())?;
-        index.enforce_equal(cs.ns(|| "index enforce equal"), &previous_plus_one)?;
+
+        let index_bit = YToBitGadget::<Parameters>::is_eq_zero(
+            &mut cs.ns(|| "is index zero"),
+            index,
+        )?.not();
+        index.conditional_enforce_equal(cs.ns(|| "index enforce equal"), &previous_plus_one, &index_bit)?;
         Ok(())
     }
 
@@ -265,6 +270,8 @@ mod tests {
             (1, 3, false),
             (3, 1, false),
             (100, 101, true),
+            (1, 0, true),
+            (5, 0, true),
         ] {
             let mut cs = TestConstraintSystem::<Fr>::new();
             let epoch1 = to_fr(&mut cs.ns(|| "1"), Some(*index1)).unwrap();

--- a/crates/epoch-snark/src/gadgets/epochs.rs
+++ b/crates/epoch-snark/src/gadgets/epochs.rs
@@ -2,13 +2,17 @@
 //!
 //! Prove the validator state transition function for the BLS 12-377 curve.
 
-use algebra::{bls12_377::{Bls12_377, Parameters, G1Projective, G2Projective}, bw6_761::Fr, ProjectiveCurve, PairingEngine};
+use algebra::{
+    bls12_377::{Bls12_377, G1Projective, G2Projective, Parameters},
+    bw6_761::Fr,
+    PairingEngine, ProjectiveCurve,
+};
 use r1cs_std::prelude::*;
 use r1cs_std::{
-    pairing::PairingGadget as _,
     bls12_377::{G1Gadget, G2Gadget, PairingGadget},
     bls12_377::{G1PreparedGadget, G2PreparedGadget},
     fields::fp::FpGadget,
+    pairing::PairingGadget as _,
     Assignment,
 };
 use tracing::{debug, info, span, Level};
@@ -190,7 +194,8 @@ impl ValidatorSetUpdate<Bls12_377> {
             let index_bit = YToBitGadget::<Parameters>::is_eq_zero(
                 &mut cs.ns(|| format!("is index {} zero", i)),
                 &constrained_epoch.index,
-            )?.not();
+            )?
+            .not();
 
             // Update the pubkeys for the next iteration
             previous_epoch_index = FrGadget::conditionally_select(
@@ -199,16 +204,22 @@ impl ValidatorSetUpdate<Bls12_377> {
                 &constrained_epoch.index,
                 &previous_epoch_index,
             )?;
-            previous_pubkey_vars = constrained_epoch.new_pubkeys
+            previous_pubkey_vars = constrained_epoch
+                .new_pubkeys
                 .iter()
                 .zip(previous_pubkey_vars.iter())
                 .enumerate()
-                .map(|(j, (new_pk, old_pk))| G2Gadget::conditionally_select(
-                    cs.ns(|| format!("conditionally update previous pub key {} in epoch {}", j, i)),
-                    &index_bit,
-                    new_pk,
-                    old_pk,
-                )).collect::<Result<Vec<_>, _>>()?;
+                .map(|(j, (new_pk, old_pk))| {
+                    G2Gadget::conditionally_select(
+                        cs.ns(|| {
+                            format!("conditionally update previous pub key {} in epoch {}", j, i)
+                        }),
+                        &index_bit,
+                        new_pk,
+                        old_pk,
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()?;
             previous_max_non_signers = FrGadget::conditionally_select(
                 cs.ns(|| format!("conditionally update previous max non signers {}", i)),
                 &index_bit,
@@ -456,14 +467,14 @@ mod tests {
 
             let epochs = [
                 &epochs[0..3],
-                &[generate_dummy_update(num_validators), generate_dummy_update(num_validators)],
+                &[
+                    generate_dummy_update(num_validators),
+                    generate_dummy_update(num_validators),
+                ],
                 &[epochs[3].clone()],
-            ].concat();
-            let asigs = [
-                &asigs[0..3],
-                &[dummy_sig, dummy_sig],
-                &[asigs[3].clone()],
-            ].concat();
+            ]
+            .concat();
+            let asigs = [&asigs[0..3], &[dummy_sig, dummy_sig], &[asigs[3].clone()]].concat();
             let aggregated_signature = sum(&asigs);
 
             let valset = ValidatorSetUpdate::<Curve> {
@@ -549,14 +560,14 @@ mod tests {
 
             let epochs = [
                 &epochs[0..3],
-                &[generate_dummy_update(num_validators), generate_dummy_update(num_validators)],
+                &[
+                    generate_dummy_update(num_validators),
+                    generate_dummy_update(num_validators),
+                ],
                 &[epochs[3].clone()],
-            ].concat();
-            let asigs = [
-                &asigs[0..3],
-                &[dummy_sig, dummy_sig],
-                &[asigs[3].clone()],
-            ].concat();
+            ]
+            .concat();
+            let asigs = [&asigs[0..3], &[dummy_sig, dummy_sig], &[asigs[3].clone()]].concat();
             let aggregated_signature = sum(&asigs);
 
             let valset = ValidatorSetUpdate::<Curve> {

--- a/crates/epoch-snark/src/gadgets/epochs.rs
+++ b/crates/epoch-snark/src/gadgets/epochs.rs
@@ -461,7 +461,7 @@ mod tests {
 
             // dummy sig is the same as the message, since sk is 1.
             let dummy_message = G1Projective::prime_subgroup_generator();
-            let dummy_sig = dummy_message.clone();
+            let dummy_sig = dummy_message;
 
             let asigs = sign_batch::<Bls12_377>(&signers_filtered, &epoch_hashes);
 
@@ -474,7 +474,7 @@ mod tests {
                 &[epochs[3].clone()],
             ]
             .concat();
-            let asigs = [&asigs[0..3], &[dummy_sig, dummy_sig], &[asigs[3].clone()]].concat();
+            let asigs = [&asigs[0..3], &[dummy_sig, dummy_sig], &[asigs[3]]].concat();
             let aggregated_signature = sum(&asigs);
 
             let valset = ValidatorSetUpdate::<Curve> {
@@ -554,7 +554,7 @@ mod tests {
 
             // dummy sig is the same as the message, since sk is 1.
             let dummy_message = G1Projective::prime_subgroup_generator();
-            let dummy_sig = dummy_message.clone();
+            let dummy_sig = dummy_message;
 
             let asigs = sign_batch::<Bls12_377>(&signers_filtered, &epoch_hashes);
 
@@ -567,7 +567,7 @@ mod tests {
                 &[epochs[3].clone()],
             ]
             .concat();
-            let asigs = [&asigs[0..3], &[dummy_sig, dummy_sig], &[asigs[3].clone()]].concat();
+            let asigs = [&asigs[0..3], &[dummy_sig, dummy_sig], &[asigs[3]]].concat();
             let aggregated_signature = sum(&asigs);
 
             let valset = ValidatorSetUpdate::<Curve> {

--- a/crates/epoch-snark/src/gadgets/epochs.rs
+++ b/crates/epoch-snark/src/gadgets/epochs.rs
@@ -2,9 +2,10 @@
 //!
 //! Prove the validator state transition function for the BLS 12-377 curve.
 
-use algebra::{bls12_377::Bls12_377, bw6_761::Fr};
+use algebra::{bls12_377::{Bls12_377, Parameters, G1Projective, G2Projective}, bw6_761::Fr, ProjectiveCurve, PairingEngine};
 use r1cs_std::prelude::*;
 use r1cs_std::{
+    pairing::PairingGadget as _,
     bls12_377::{G1Gadget, G2Gadget, PairingGadget},
     bls12_377::{G1PreparedGadget, G2PreparedGadget},
     fields::fp::FpGadget,
@@ -14,12 +15,11 @@ use tracing::{debug, info, span, Level};
 
 use r1cs_core::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
 
-use algebra::PairingEngine;
 use groth16::{Proof, VerifyingKey};
 
 use crate::gadgets::{g2_to_bits, single_update::SingleUpdate, EpochBits, EpochData};
 
-use bls_gadgets::BlsVerifyGadget;
+use bls_gadgets::{BlsVerifyGadget, YToBitGadget};
 type BlsGadget = BlsVerifyGadget<Bls12_377, Fr, PairingGadget>;
 type FrGadget = FpGadget<Fr>;
 
@@ -158,6 +158,15 @@ impl ValidatorSetUpdate<Bls12_377> {
         let span = span!(Level::TRACE, "verify_intermediate_epochs");
         let _enter = span.enter();
 
+        let dummy_pk = G2Gadget::alloc_constant(
+            cs.ns(|| "dummy public key"),
+            G2Projective::prime_subgroup_generator(),
+        )?;
+        let dummy_message = G1Gadget::alloc_constant(
+            cs.ns(|| "dummy sig"),
+            G1Projective::prime_subgroup_generator(),
+        )?;
+
         let mut prepared_aggregated_public_keys = vec![];
         let mut prepared_message_hashes = vec![];
         let mut last_epoch_bits = vec![];
@@ -178,14 +187,62 @@ impl ValidatorSetUpdate<Bls12_377> {
                 self.hash_helper.is_none(), // generate constraints in BW6_761 if no helper was provided
             )?;
 
+            let index_bit = YToBitGadget::<Parameters>::is_eq_zero(
+                &mut cs.ns(|| format!("is index {} zero", i)),
+                &constrained_epoch.index,
+            )?.not();
+
             // Update the pubkeys for the next iteration
-            previous_epoch_index = constrained_epoch.index;
-            previous_pubkey_vars = constrained_epoch.new_pubkeys;
-            previous_max_non_signers = constrained_epoch.new_max_non_signers;
+            previous_epoch_index = FrGadget::conditionally_select(
+                cs.ns(|| format!("conditionally update previous epoch index {}", i)),
+                &index_bit,
+                &constrained_epoch.index,
+                &previous_epoch_index,
+            )?;
+            previous_pubkey_vars = constrained_epoch.new_pubkeys
+                .iter()
+                .zip(previous_pubkey_vars.iter())
+                .enumerate()
+                .map(|(j, (new_pk, old_pk))| G2Gadget::conditionally_select(
+                    cs.ns(|| format!("conditionally update previous pub key {} in epoch {}", j, i)),
+                    &index_bit,
+                    new_pk,
+                    old_pk,
+                )).collect::<Result<Vec<_>, _>>()?;
+            previous_max_non_signers = FrGadget::conditionally_select(
+                cs.ns(|| format!("conditionally update previous max non signers {}", i)),
+                &index_bit,
+                &constrained_epoch.new_max_non_signers,
+                &previous_max_non_signers,
+            )?;
+
+            let aggregate_pk = G2Gadget::conditionally_select(
+                cs.ns(|| format!("conditionally select aggregate pk in epoch {}", i)),
+                &index_bit,
+                &constrained_epoch.aggregate_pk,
+                &dummy_pk,
+            )?;
+
+            let prepared_aggregate_pk = PairingGadget::prepare_g2(
+                cs.ns(|| format!("prepare aggregate pk in epoch {}", i)),
+                &aggregate_pk,
+            )?;
+
+            let message_hash = G1Gadget::conditionally_select(
+                cs.ns(|| format!("conditionally select message hash in epoch {}", i)),
+                &index_bit,
+                &constrained_epoch.message_hash,
+                &dummy_message,
+            )?;
+
+            let prepared_message_hash = PairingGadget::prepare_g1(
+                cs.ns(|| format!("prepare message hash in epoch {}", i)),
+                &message_hash,
+            )?;
 
             // Save the aggregated pubkey / message hash pair for the BLS batch verification
-            prepared_aggregated_public_keys.push(constrained_epoch.aggregate_pk);
-            prepared_message_hashes.push(constrained_epoch.message_hash);
+            prepared_aggregated_public_keys.push(prepared_aggregate_pk);
+            prepared_message_hashes.push(prepared_message_hash);
 
             // Save the xof/crh and the last epoch's bits for compressing the public inputs
             all_crh_bits.extend_from_slice(&constrained_epoch.crh_bits);
@@ -199,6 +256,12 @@ impl ValidatorSetUpdate<Bls12_377> {
                     g2_to_bits(&mut cs.ns(|| "last epoch aggregated pk bits"), &last_apk)?;
                 last_epoch_bits = constrained_epoch.bits;
                 last_epoch_bits.extend_from_slice(&last_apk_bits);
+
+                // make sure the last epoch index is not zero
+                index_bit.enforce_equal(
+                    cs.ns(|| "last epoch index is not zero"),
+                    &Boolean::Constant(true),
+                )?;
             }
             debug!("epoch {} constrained", i);
         }
@@ -240,7 +303,7 @@ mod tests {
     use super::*;
 
     use crate::gadgets::single_update::test_helpers::generate_single_update;
-    use algebra::bls12_377::G1Projective;
+    use algebra::{bls12_377::G1Projective, ProjectiveCurve};
     use bls_crypto::test_helpers::{keygen_batch, keygen_mul, sign_batch, sum};
     use r1cs_std::test_constraint_system::TestConstraintSystem;
 
@@ -249,6 +312,7 @@ mod tests {
     // let's run our tests with 7 validators and 2 faulty ones
     mod epoch_batch_verification {
         use super::*;
+        use crate::gadgets::single_update::test_helpers::generate_dummy_update;
 
         #[test]
         fn test_multiple_epochs() {
@@ -322,6 +386,192 @@ mod tests {
 
             let mut cs = TestConstraintSystem::<Fr>::new();
             valset.enforce(&mut cs).unwrap();
+            assert!(cs.is_satisfied());
+        }
+
+        #[test]
+        fn test_multiple_epochs_with_dummy() {
+            let faults: u32 = 2;
+            let num_validators = 3 * faults + 1;
+            let initial_validator_set = keygen_mul::<Curve>(num_validators as usize);
+            let initial_epoch =
+                generate_single_update::<Curve>(0, faults, &initial_validator_set.1, &[])
+                    .epoch_data;
+
+            let num_epochs = 4;
+            // no more than `faults` 0s exist in the bitmap
+            // (i.e. at most `faults` validators who do not sign on the next validator set)
+            let bitmaps = &[
+                &[true, true, false, true, true, true, true],
+                &[true, true, false, true, true, true, true],
+                &[true, true, true, true, false, false, true],
+                &[true, true, true, true, true, true, true],
+            ];
+            // Generate validators for each of the epochs
+            let validators = keygen_batch::<Curve>(num_epochs, num_validators as usize);
+            // Generate `num_epochs` epochs
+            let epochs = validators
+                .1
+                .iter()
+                .enumerate()
+                .map(|(epoch_index, epoch_validators)| {
+                    generate_single_update::<Curve>(
+                        epoch_index as u16 + 1,
+                        faults,
+                        epoch_validators,
+                        bitmaps[epoch_index],
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            // The i-th validator set, signs on the i+1th epoch's G1 hash
+            let mut signers = vec![initial_validator_set.0];
+            signers.extend_from_slice(&validators.0[..validators.1.len() - 1]);
+
+            // Filter the private keys which had a 1 in the boolean per epoch
+            let mut signers_filtered = Vec::new();
+            for i in 0..signers.len() {
+                let mut epoch_signers_filtered = Vec::new();
+                let epoch_signers = &signers[i];
+                let epoch_bitmap = bitmaps[i];
+                for (j, epoch_signer) in epoch_signers.iter().enumerate() {
+                    if epoch_bitmap[j] {
+                        epoch_signers_filtered.push(*epoch_signer);
+                    }
+                }
+                signers_filtered.push(epoch_signers_filtered);
+            }
+
+            use crate::gadgets::test_helpers::hash_epoch;
+            let epoch_hashes = epochs
+                .iter()
+                .map(|update| hash_epoch(&update.epoch_data))
+                .collect::<Vec<G1Projective>>();
+
+            // dummy sig is the same as the message, since sk is 1.
+            let dummy_message = G1Projective::prime_subgroup_generator();
+            let dummy_sig = dummy_message.clone();
+
+            let asigs = sign_batch::<Bls12_377>(&signers_filtered, &epoch_hashes);
+
+            let epochs = [
+                &epochs[0..3],
+                &[generate_dummy_update(num_validators), generate_dummy_update(num_validators)],
+                &[epochs[3].clone()],
+            ].concat();
+            let asigs = [
+                &asigs[0..3],
+                &[dummy_sig, dummy_sig],
+                &[asigs[3].clone()],
+            ].concat();
+            let aggregated_signature = sum(&asigs);
+
+            let valset = ValidatorSetUpdate::<Curve> {
+                initial_epoch,
+                epochs,
+                num_validators,
+                aggregated_signature: Some(aggregated_signature),
+                hash_helper: None,
+            };
+
+            let mut cs = TestConstraintSystem::<Fr>::new();
+            valset.enforce(&mut cs).unwrap();
+            if !cs.is_satisfied() {
+                println!("unsatisfied: {}", cs.which_is_unsatisfied().unwrap());
+            }
+            assert!(cs.is_satisfied());
+        }
+
+        #[test]
+        fn test_multiple_epochs_with_wrong_dummy() {
+            let faults: u32 = 2;
+            let num_validators = 3 * faults + 1;
+            let initial_validator_set = keygen_mul::<Curve>(num_validators as usize);
+            let initial_epoch =
+                generate_single_update::<Curve>(0, faults, &initial_validator_set.1, &[])
+                    .epoch_data;
+
+            let num_epochs = 4;
+            // no more than `faults` 0s exist in the bitmap
+            // (i.e. at most `faults` validators who do not sign on the next validator set)
+            let bitmaps = &[
+                &[true, true, false, true, true, true, true],
+                &[true, true, false, true, true, true, true],
+                &[true, true, true, true, false, false, true],
+                &[true, true, true, true, true, true, true],
+            ];
+            // Generate validators for each of the epochs
+            let validators = keygen_batch::<Curve>(num_epochs, num_validators as usize);
+            // Generate `num_epochs` epochs
+            let epochs = validators
+                .1
+                .iter()
+                .enumerate()
+                .map(|(epoch_index, epoch_validators)| {
+                    generate_single_update::<Curve>(
+                        epoch_index as u16 + 1,
+                        faults,
+                        epoch_validators,
+                        bitmaps[epoch_index],
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            // The i-th validator set, signs on the i+1th epoch's G1 hash
+            let mut signers = vec![initial_validator_set.0];
+            signers.extend_from_slice(&validators.0[..validators.1.len() - 1]);
+
+            // Filter the private keys which had a 1 in the boolean per epoch
+            let mut signers_filtered = Vec::new();
+            for i in 0..signers.len() {
+                let mut epoch_signers_filtered = Vec::new();
+                let epoch_signers = &signers[i];
+                let epoch_bitmap = bitmaps[i];
+                for (j, epoch_signer) in epoch_signers.iter().enumerate() {
+                    if epoch_bitmap[j] {
+                        epoch_signers_filtered.push(*epoch_signer);
+                    }
+                }
+                signers_filtered.push(epoch_signers_filtered);
+            }
+
+            use crate::gadgets::test_helpers::hash_epoch;
+            let epoch_hashes = epochs
+                .iter()
+                .map(|update| hash_epoch(&update.epoch_data))
+                .collect::<Vec<G1Projective>>();
+
+            // dummy sig is the same as the message, since sk is 1.
+            let dummy_message = G1Projective::prime_subgroup_generator();
+            let dummy_sig = dummy_message.clone();
+
+            let asigs = sign_batch::<Bls12_377>(&signers_filtered, &epoch_hashes);
+
+            let epochs = [
+                &epochs[0..3],
+                &[generate_dummy_update(num_validators), generate_dummy_update(num_validators)],
+                &[epochs[3].clone()],
+            ].concat();
+            let asigs = [
+                &asigs[0..3],
+                &[dummy_sig, dummy_sig],
+                &[asigs[3].clone()],
+            ].concat();
+            let aggregated_signature = sum(&asigs);
+
+            let valset = ValidatorSetUpdate::<Curve> {
+                initial_epoch,
+                epochs,
+                num_validators,
+                aggregated_signature: Some(aggregated_signature),
+                hash_helper: None,
+            };
+
+            let mut cs = TestConstraintSystem::<Fr>::new();
+            valset.enforce(&mut cs).unwrap();
+            if !cs.is_satisfied() {
+                println!("unsatisfied: {}", cs.which_is_unsatisfied().unwrap());
+            }
             assert!(cs.is_satisfied());
         }
     }

--- a/crates/epoch-snark/src/gadgets/single_update.rs
+++ b/crates/epoch-snark/src/gadgets/single_update.rs
@@ -91,14 +91,13 @@ impl SingleUpdate<Bls12_377> {
 
         // Verify that the bitmap is consistent with the pubkeys read from the
         // previous epoch and prepare the message hash and the aggregate pk
-        let (message_hash, aggregated_public_key) =
-            BlsGadget::enforce_bitmap(
-                cs.ns(|| "verify signature partial"),
-                previous_pubkeys,
-                &signed_bitmap,
-                &epoch_data.message_hash,
-                &previous_max_non_signers,
-            )?;
+        let (message_hash, aggregated_public_key) = BlsGadget::enforce_bitmap(
+            cs.ns(|| "verify signature partial"),
+            previous_pubkeys,
+            &signed_bitmap,
+            &epoch_data.message_hash,
+            &previous_max_non_signers,
+        )?;
 
         Ok(ConstrainedEpoch {
             new_pubkeys: epoch_data.pubkeys,
@@ -137,11 +136,11 @@ pub mod test_helpers {
         }
     }
 
-    pub fn generate_dummy_update<E: PairingEngine>(
-        num_validators: u32,
-    ) -> SingleUpdate<E> {
+    pub fn generate_dummy_update<E: PairingEngine>(num_validators: u32) -> SingleUpdate<E> {
         let bitmap = (0..num_validators).map(|_| true).collect::<Vec<_>>();
-        let public_keys = (0..num_validators).map(|_| E::G2Projective::prime_subgroup_generator()).collect::<Vec<_>>();
+        let public_keys = (0..num_validators)
+            .map(|_| E::G2Projective::prime_subgroup_generator())
+            .collect::<Vec<_>>();
         let epoch_data = EpochData::<E> {
             index: Some(0),
             maximum_non_signers: 0u32,

--- a/crates/epoch-snark/src/gadgets/single_update.rs
+++ b/crates/epoch-snark/src/gadgets/single_update.rs
@@ -1,7 +1,7 @@
 use algebra::{bls12_377::Bls12_377, bw6_761::Fr, PairingEngine};
 use r1cs_core::{ConstraintSystem, SynthesisError};
 use r1cs_std::{
-    bls12_377::{G1PreparedGadget, G2Gadget, G2PreparedGadget, PairingGadget},
+    bls12_377::{G1Gadget, G2Gadget, PairingGadget},
     boolean::Boolean,
     fields::fp::FpGadget,
 };
@@ -44,10 +44,10 @@ pub struct ConstrainedEpoch {
     /// The new threshold needed for signatures
     pub new_max_non_signers: FrGadget,
     /// The epoch's G1 Hash
-    pub message_hash: G1PreparedGadget,
+    pub message_hash: G1Gadget,
     /// The aggregate pubkey based on the bitmap of the validators
     /// of the previous epoch
-    pub aggregate_pk: G2PreparedGadget,
+    pub aggregate_pk: G2Gadget,
     /// The epoch's index
     pub index: FrGadget,
     /// Serialized epoch data containing the index, max non signers, aggregated pubkey and the pubkeys array
@@ -91,8 +91,8 @@ impl SingleUpdate<Bls12_377> {
 
         // Verify that the bitmap is consistent with the pubkeys read from the
         // previous epoch and prepare the message hash and the aggregate pk
-        let (prepared_message_hash, prepared_aggregated_public_key) =
-            BlsGadget::enforce_bitmap_and_prepare(
+        let (message_hash, aggregated_public_key) =
+            BlsGadget::enforce_bitmap(
                 cs.ns(|| "verify signature partial"),
                 previous_pubkeys,
                 &signed_bitmap,
@@ -103,8 +103,8 @@ impl SingleUpdate<Bls12_377> {
         Ok(ConstrainedEpoch {
             new_pubkeys: epoch_data.pubkeys,
             new_max_non_signers: epoch_data.maximum_non_signers,
-            message_hash: prepared_message_hash,
-            aggregate_pk: prepared_aggregated_public_key,
+            message_hash,
+            aggregate_pk: aggregated_public_key,
             index: epoch_data.index,
             bits: epoch_data.bits,
             xof_bits: epoch_data.xof_bits,
@@ -117,6 +117,7 @@ impl SingleUpdate<Bls12_377> {
 pub mod test_helpers {
     use super::*;
     use crate::gadgets::test_helpers::to_option_iter;
+    use algebra::ProjectiveCurve;
 
     pub fn generate_single_update<E: PairingEngine>(
         index: u16,
@@ -133,6 +134,23 @@ pub mod test_helpers {
         SingleUpdate::<E> {
             epoch_data,
             signed_bitmap: to_option_iter(bitmap),
+        }
+    }
+
+    pub fn generate_dummy_update<E: PairingEngine>(
+        num_validators: u32,
+    ) -> SingleUpdate<E> {
+        let bitmap = (0..num_validators).map(|_| true).collect::<Vec<_>>();
+        let public_keys = (0..num_validators).map(|_| E::G2Projective::prime_subgroup_generator()).collect::<Vec<_>>();
+        let epoch_data = EpochData::<E> {
+            index: Some(0),
+            maximum_non_signers: 0u32,
+            public_keys: to_option_iter(public_keys.as_slice()),
+        };
+
+        SingleUpdate::<E> {
+            epoch_data,
+            signed_bitmap: to_option_iter(&bitmap),
         }
     }
 }

--- a/crates/epoch-snark/tests/e2e.rs
+++ b/crates/epoch-snark/tests/e2e.rs
@@ -30,7 +30,14 @@ fn prover_verifier_groth16() {
         generate_test_data(num_validators, faults, num_transitions);
 
     // Prover generates the proof given the params
-    let proof = prove(&params, num_validators as u32, &first_epoch, &transitions, num_transitions).unwrap();
+    let proof = prove(
+        &params,
+        num_validators as u32,
+        &first_epoch,
+        &transitions,
+        num_transitions,
+    )
+    .unwrap();
 
     // Verifier checks the proof
     let res = verify(&params.epochs.vk, &first_epoch, &last_epoch, &proof);
@@ -77,7 +84,7 @@ fn prover_verifier_groth16_with_dummy() {
         rng,
         hashes_in_bls12_377,
     )
-        .unwrap();
+    .unwrap();
 
     // Create the state to be proven (first epoch + `num_transitions` transitions.
     // Note: This is all data which should be fetched via the Celo blockchain
@@ -85,7 +92,14 @@ fn prover_verifier_groth16_with_dummy() {
         generate_test_data(num_validators, faults, num_transitions);
 
     // Prover generates the proof given the params
-    let proof = prove(&params, num_validators as u32, &first_epoch, &transitions, max_transitions).unwrap();
+    let proof = prove(
+        &params,
+        num_validators as u32,
+        &first_epoch,
+        &transitions,
+        max_transitions,
+    )
+    .unwrap();
 
     // Verifier checks the proof
     let res = verify(&params.epochs.vk, &first_epoch, &last_epoch, &proof);

--- a/crates/epoch-snark/tests/e2e.rs
+++ b/crates/epoch-snark/tests/e2e.rs
@@ -12,7 +12,7 @@ fn prover_verifier_groth16() {
     let faults = 1;
     let num_validators = 3 * faults + 1;
 
-    let hashes_in_bls12_377 = true;
+    let hashes_in_bls12_377 = false;
 
     // Trusted setup
     let params = trusted_setup(
@@ -30,7 +30,62 @@ fn prover_verifier_groth16() {
         generate_test_data(num_validators, faults, num_transitions);
 
     // Prover generates the proof given the params
-    let proof = prove(&params, num_validators as u32, &first_epoch, &transitions).unwrap();
+    let proof = prove(&params, num_validators as u32, &first_epoch, &transitions, num_transitions).unwrap();
+
+    // Verifier checks the proof
+    let res = verify(&params.epochs.vk, &first_epoch, &last_epoch, &proof);
+    assert!(res.is_ok());
+
+    // Serialize the proof / vk
+    let mut serialized_vk = vec![];
+    params.epochs.vk.serialize(&mut serialized_vk).unwrap();
+    let mut serialized_proof = vec![];
+    proof.serialize(&mut serialized_proof).unwrap();
+    dbg!(hex::encode(&serialized_vk));
+    dbg!(hex::encode(&serialized_proof));
+
+    let mut first_pubkeys = vec![];
+    first_epoch
+        .new_public_keys
+        .serialize(&mut first_pubkeys)
+        .unwrap();
+    let mut last_pubkeys = vec![];
+    last_epoch
+        .new_public_keys
+        .serialize(&mut last_pubkeys)
+        .unwrap();
+    dbg!(hex::encode(&first_pubkeys));
+    dbg!(hex::encode(&last_pubkeys));
+}
+
+#[test]
+#[ignore] // This test makes CI run out of memory and takes too long. It works though!
+fn prover_verifier_groth16_with_dummy() {
+    let rng = &mut rand::thread_rng();
+    let num_transitions = 2;
+    let max_transitions = num_transitions + 10;
+    let faults = 1;
+    let num_validators = 3 * faults + 1;
+
+    let hashes_in_bls12_377 = false;
+
+    // Trusted setup
+    let params = trusted_setup(
+        num_validators,
+        max_transitions,
+        faults,
+        rng,
+        hashes_in_bls12_377,
+    )
+        .unwrap();
+
+    // Create the state to be proven (first epoch + `num_transitions` transitions.
+    // Note: This is all data which should be fetched via the Celo blockchain
+    let (first_epoch, transitions, last_epoch) =
+        generate_test_data(num_validators, faults, num_transitions);
+
+    // Prover generates the proof given the params
+    let proof = prove(&params, num_validators as u32, &first_epoch, &transitions, max_transitions).unwrap();
 
     // Verifier checks the proof
     let res = verify(&params.epochs.vk, &first_epoch, &last_epoch, &proof);


### PR DESCRIPTION
### Description

In order to have the circuit have a maximum number of epochs, but still support proving a smaller number of epochs, we add the support of padding with dummy epochs.

Regular epochs have index > 1.

These epochs have the following properties:
* Index = 0.
* Public keys are all the generator of G2.

We change the circuit logic to perform the following:
* Instead of enforcing the epoch index is sequential, it enforces it only if the new index is not zero.
* In the processing loop, `previous_epoch_index`, `previous_public_keys` and `previous_maximum_non_signers` are updated only if the index is not zero.
* The aggregated public key that's used in the miller loop for that epoch is chosen to be the generator for G2. This is conditionally chosen based on the epoch index being zero.
* The message hash that's  that's used in the miller loop for that epoch is chosen to be the generator for G1. This is conditionally chosen based on the epoch index being zero.
* The over-all aggregated signature gets the generator for G1 as the contribution for that epoch. This works since `sig = G1, pk = G2, H(m) = G1` satisfy `e(H(m), pk) = e(sig, G2)` because it's `e(G1, G2) = e(G1, G2)`.
* The last epoch index is enforced to be non-zero.

### Tested

We add tests for proofs with dummy epochs.
