### PR TITLE
Ensure all msgs are batch verified + don't re-alloc

### DIFF
--- a/crates/bls-crypto/src/bls/signature.rs
+++ b/crates/bls-crypto/src/bls/signature.rs
@@ -84,6 +84,9 @@ impl Signature {
         messages: &[(&[u8], &[u8])],
         hash_to_g1: &H,
     ) -> Result<(), BLSError> {
+        if pubkeys.len() != messages.len() {
+            return Err(BLSError::UnevenNumKeysMessages);
+        };
         let message_hashes = messages
             .iter()
             .map(|(message, extra_data)| hash_to_g1.hash(domain, message, extra_data))
@@ -103,11 +106,15 @@ impl Signature {
         pubkeys: &[P],
         message_hashes: &[G1Projective],
     ) -> Result<(), BLSError> {
+        if pubkeys.len() != message_hashes.len() {
+            return Err(BLSError::UnevenNumKeysMessages);
+        };
         // `.into()` is needed to prepared the points
-        let mut els = vec![(
+        let mut els = Vec::with_capacity(message_hashes.len() + 1);
+        els.push((
             self.as_ref().into_affine().into(),
             G2Affine::prime_subgroup_generator().neg().into(),
-        )];
+        ));
         message_hashes
             .iter()
             .zip(pubkeys)

--- a/crates/bls-crypto/src/lib.rs
+++ b/crates/bls-crypto/src/lib.rs
@@ -103,6 +103,10 @@ pub enum BLSError {
     #[error("Could not hash to curve")]
     HashToCurveError,
 
+    /// There must be the same number of keys and messages
+    #[error("there must be the same number of keys and messages")]
+    UnevenNumKeysMessages,
+
     /// Serialization error in Zexe
     #[error(transparent)]
     SerializationError(#[from] algebra::SerializationError),


### PR DESCRIPTION
If there are more messages that public keys only the messages that have public keys are verified because of how zip works. Also, allocate (message hash, pubkey) `Vec` using `with_capacity` to avoid needing to re-alloc.