### PR TITLE
feat: adds previous epoch hash to the circuit

### DIFF
--- a/crates/bls-crypto/src/hash_to_curve/mod.rs
+++ b/crates/bls-crypto/src/hash_to_curve/mod.rs
@@ -38,7 +38,7 @@
 /// let hash = hasher.hash(OUT_DOMAIN, &b"some_data"[..], &b"extra"[..]).expect("should not fail");
 ///
 /// // You can also use the underlying struct's method to get the counter
-/// let (hash, counter) = hasher.hash_with_attempt(OUT_DOMAIN, &b"some_data"[..], &b"extra"[..]).expect("should not fail");
+/// let (hash, xof_hash, counter) = hasher.hash_with_attempt(OUT_DOMAIN, &b"some_data"[..], &b"extra"[..]).expect("should not fail");
 /// assert_eq!(counter, 3);
 /// ```
 pub mod try_and_increment;

--- a/crates/bls-crypto/src/hash_to_curve/try_and_increment.rs
+++ b/crates/bls-crypto/src/hash_to_curve/try_and_increment.rs
@@ -84,7 +84,7 @@ where
         domain: &[u8],
         message: &[u8],
         extra_data: &[u8],
-    ) -> Result<(GroupProjective<P>, usize), BLSError> {
+    ) -> Result<(GroupProjective<P>, Vec<u8>, usize), BLSError> {
         let num_bytes = GroupAffine::<P>::SERIALIZED_SIZE;
         let hash_loop_time = start_timer!(|| "try_and_increment::hash_loop");
         let hash_bytes = hash_length(num_bytes);
@@ -127,7 +127,7 @@ where
                     continue;
                 }
 
-                return Ok((scaled, c as usize));
+                return Ok((scaled, candidate_hash[..num_bytes].to_vec(), c as usize));
             }
         }
         Err(BLSError::HashToCurveError)

--- a/crates/bls-gadgets/src/hash_to_group.rs
+++ b/crates/bls-gadgets/src/hash_to_group.rs
@@ -390,7 +390,7 @@ mod test {
 
     fn hash_to_group(input: &[u8]) {
         let try_and_increment = &*COMPOSITE_HASH_TO_G1;
-        let (expected_hash, attempt) = try_and_increment
+        let (expected_hash, _, attempt) = try_and_increment
             .hash_with_attempt(SIG_DOMAIN, input, &[])
             .unwrap();
 

--- a/crates/bls-snark-sys/src/snark/epoch_block.rs
+++ b/crates/bls-snark-sys/src/snark/epoch_block.rs
@@ -15,6 +15,8 @@ const PUBKEY_BYTES: usize = 96;
 
 #[no_mangle]
 pub extern "C" fn encode_epoch_block_to_bytes(
+    in_pervious_epoch_hash: *const u8,
+    in_pervious_epoch_hash_len: c_int,
     in_epoch_index: c_ushort,
     in_maximum_non_signers: c_uint,
     in_added_public_keys: *const *const PublicKey,
@@ -24,6 +26,9 @@ pub extern "C" fn encode_epoch_block_to_bytes(
     out_len: *mut c_int,
 ) -> bool {
     convert_result_to_bool::<_, EncodingError, _>(|| {
+        let previous_epoch_hash = unsafe {
+            slice::from_raw_parts(in_pervious_epoch_hash, in_pervious_epoch_hash_len as usize)
+        };
         let added_public_keys_ptrs = unsafe {
             slice::from_raw_parts(in_added_public_keys, in_added_public_keys_len as usize)
         };
@@ -34,6 +39,7 @@ pub extern "C" fn encode_epoch_block_to_bytes(
             .collect::<Vec<PublicKey>>();
 
         let epoch_block = EpochBlock::new(
+            previous_epoch_hash,
             in_epoch_index as u16,
             in_maximum_non_signers as u32,
             added_public_keys,

--- a/crates/bls-snark-sys/src/snark/mod.rs
+++ b/crates/bls-snark-sys/src/snark/mod.rs
@@ -64,6 +64,8 @@ mod tests {
         let last_pubkeys = hex::decode(LAST_PUBKEYS).unwrap();
 
         let first_epoch = EpochBlockFFI {
+            previous_epoch_hash: std::ptr::null() as *const u8,
+            previous_epoch_hash_len: 0,
             index: 0,
             maximum_non_signers: 1,
             pubkeys_num: 4,
@@ -71,6 +73,8 @@ mod tests {
         };
 
         let last_epoch = EpochBlockFFI {
+            previous_epoch_hash: std::ptr::null() as *const u8,
+            previous_epoch_hash_len: 0,
             index: 2,
             maximum_non_signers: 1,
             pubkeys_num: 4,

--- a/crates/epoch-snark/src/api/prover.rs
+++ b/crates/epoch-snark/src/api/prover.rs
@@ -14,8 +14,8 @@ use bls_gadgets::utils::bytes_to_bits;
 use groth16::{create_proof_no_zk, Parameters as Groth16Parameters, Proof as Groth16Proof};
 use r1cs_core::SynthesisError;
 
-use tracing::{info, span, Level};
 use crate::encoding::PREVIOUS_EPOCH_HASH_BITS;
+use tracing::{info, span, Level};
 
 /// Given the SNARK's Public Parameters, the initial epoch, and a list of state transitions,
 /// generates a SNARK which proves that the final epoch is correctly calculated from the first

--- a/crates/epoch-snark/src/encoding.rs
+++ b/crates/epoch-snark/src/encoding.rs
@@ -17,6 +17,8 @@ pub enum EncodingError {
     IoError(#[from] std::io::Error),
 }
 
+pub const PREVIOUS_EPOCH_HASH_BITS: usize = 128;
+
 /// The function assumes that the public key is not the point in infinity, which is true for
 /// BLS public keys
 pub fn encode_public_key(public_key: &PublicKey) -> Result<Vec<bool>, EncodingError> {

--- a/crates/epoch-snark/src/epoch_block.rs
+++ b/crates/epoch-snark/src/epoch_block.rs
@@ -2,10 +2,11 @@ use super::encoding::{encode_public_key, encode_u16, encode_u32, EncodingError};
 use algebra::bls12_377::G1Projective;
 use blake2s_simd::Params;
 use bls_crypto::{
-    hash_to_curve::{try_and_increment::COMPOSITE_HASH_TO_G1, HashToCurve},
+    hash_to_curve::{try_and_increment::COMPOSITE_HASH_TO_G1},
     PublicKey, Signature, OUT_DOMAIN, SIG_DOMAIN,
 };
 use bls_gadgets::utils::{bits_to_bytes, bytes_to_bits};
+use crate::PREVIOUS_EPOCH_HASH_BITS;
 
 /// A header as parsed after being fetched from the Celo Blockchain
 /// It contains information about the new epoch, as well as an aggregated
@@ -25,6 +26,8 @@ pub struct EpochTransition {
 /// Metadata about the next epoch
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EpochBlock {
+    /// The previous epoch hash
+    pub previous_epoch_hash: Vec<u8>,
     /// The block number
     pub index: u16,
     /// The maximum allowed number of signers that may be absent
@@ -35,8 +38,9 @@ pub struct EpochBlock {
 
 impl EpochBlock {
     /// Creates a new epoch block
-    pub fn new(index: u16, maximum_non_signers: u32, new_public_keys: Vec<PublicKey>) -> Self {
+    pub fn new(previous_epoch_hash: &[u8], index: u16, maximum_non_signers: u32, new_public_keys: Vec<PublicKey>) -> Self {
         Self {
+            previous_epoch_hash: previous_epoch_hash.to_vec(),
             index,
             maximum_non_signers,
             new_public_keys,
@@ -45,11 +49,11 @@ impl EpochBlock {
 
     /// Encodes the block to bytes and then proceeds to hash it to BLS12-377's G1
     /// group using `SIG_DOMAIN` as a domain separator
-    pub fn hash_to_g1(&self) -> Result<G1Projective, EncodingError> {
+    pub fn hash_to_g1(&self) -> Result<(G1Projective, Vec<u8>), EncodingError> {
         let input = self.encode_to_bytes()?;
-        let expected_hash: G1Projective =
-            COMPOSITE_HASH_TO_G1.hash(SIG_DOMAIN, &input, &[]).unwrap();
-        Ok(expected_hash)
+        let (expected_hash, expected_xof_hash, _) =
+            COMPOSITE_HASH_TO_G1.hash_with_attempt(SIG_DOMAIN, &input, &[]).unwrap();
+        Ok((expected_hash, expected_xof_hash))
     }
 
     /// Encodes the block to bytes and then hashes it with Blake2
@@ -65,6 +69,8 @@ impl EpochBlock {
     /// Encodes the block to LE bits
     pub fn encode_to_bits(&self) -> Result<Vec<bool>, EncodingError> {
         let mut epoch_bits = vec![];
+        let previous_epoch_hash_bits = bytes_to_bits(&self.previous_epoch_hash, PREVIOUS_EPOCH_HASH_BITS).into_iter().rev().collect::<Vec<_>>();
+        epoch_bits.extend_from_slice(&previous_epoch_hash_bits);
         epoch_bits.extend_from_slice(&encode_u16(self.index)?);
         epoch_bits.extend_from_slice(&encode_u32(self.maximum_non_signers)?);
         for added_public_key in &self.new_public_keys {

--- a/crates/epoch-snark/src/gadgets/epoch_data.rs
+++ b/crates/epoch-snark/src/gadgets/epoch_data.rs
@@ -118,7 +118,12 @@ impl EpochData<Bls12_377> {
             32,
         )?;
 
-        let mut epoch_bits: Vec<Boolean> = [previous_epoch_hash.to_vec(), index_bits, maximum_non_signers_bits].concat();
+        let mut epoch_bits: Vec<Boolean> = [
+            previous_epoch_hash.to_vec(),
+            index_bits,
+            maximum_non_signers_bits,
+        ]
+        .concat();
 
         let mut pubkey_vars = Vec::with_capacity(self.public_keys.len());
         for (j, maybe_pk) in self.public_keys.iter().enumerate() {
@@ -252,9 +257,14 @@ mod tests {
         }
 
         // Calculate the hash from our to_bytes function
-        let epoch_bytes = EpochBlock::new(&[], epoch.index.unwrap(), epoch.maximum_non_signers, pubkeys)
-            .encode_to_bytes()
-            .unwrap();
+        let epoch_bytes = EpochBlock::new(
+            &[],
+            epoch.index.unwrap(),
+            epoch.maximum_non_signers,
+            pubkeys,
+        )
+        .encode_to_bytes()
+        .unwrap();
         let (hash, _, _) = COMPOSITE_HASH_TO_G1
             .hash_with_attempt(SIG_DOMAIN, &epoch_bytes, &[])
             .unwrap();
@@ -304,9 +314,14 @@ mod tests {
         .unwrap();
 
         // calculate wrong bits
-        let bits_wrong = EpochBlock::new(&[], epoch.index.unwrap(), epoch.maximum_non_signers, pubkeys)
-            .encode_to_bits_with_aggregated_pk()
-            .unwrap();
+        let bits_wrong = EpochBlock::new(
+            &[],
+            epoch.index.unwrap(),
+            epoch.maximum_non_signers,
+            pubkeys,
+        )
+        .encode_to_bits_with_aggregated_pk()
+        .unwrap();
 
         // calculate the bits from the epoch
         let mut cs = TestConstraintSystem::<Fr>::new();

--- a/crates/epoch-snark/src/gadgets/mod.rs
+++ b/crates/epoch-snark/src/gadgets/mod.rs
@@ -39,16 +39,24 @@ pub mod test_helpers {
         it.iter().map(|t| Some(*t)).collect()
     }
 
-    pub fn hash_epoch(epoch: &EpochData<Bls12_377>, previous_epoch_hash: &[u8]) -> (G1Projective, Vec<u8>) {
+    pub fn hash_epoch(
+        epoch: &EpochData<Bls12_377>,
+        previous_epoch_hash: &[u8],
+    ) -> (G1Projective, Vec<u8>) {
         let mut pubkeys = Vec::new();
         for pk in &epoch.public_keys {
             pubkeys.push(PublicKey::from(pk.unwrap()));
         }
 
         // Calculate the hash from our to_bytes function
-        let epoch_bytes = EpochBlock::new(previous_epoch_hash, epoch.index.unwrap(), epoch.maximum_non_signers, pubkeys)
-            .encode_to_bytes()
-            .unwrap();
+        let epoch_bytes = EpochBlock::new(
+            previous_epoch_hash,
+            epoch.index.unwrap(),
+            epoch.maximum_non_signers,
+            pubkeys,
+        )
+        .encode_to_bytes()
+        .unwrap();
         let (hash, xof_hash, _) = COMPOSITE_HASH_TO_G1
             .hash_with_attempt(SIG_DOMAIN, &epoch_bytes, &[])
             .unwrap();

--- a/crates/epoch-snark/src/gadgets/mod.rs
+++ b/crates/epoch-snark/src/gadgets/mod.rs
@@ -39,21 +39,21 @@ pub mod test_helpers {
         it.iter().map(|t| Some(*t)).collect()
     }
 
-    pub fn hash_epoch(epoch: &EpochData<Bls12_377>) -> G1Projective {
+    pub fn hash_epoch(epoch: &EpochData<Bls12_377>, previous_epoch_hash: &[u8]) -> (G1Projective, Vec<u8>) {
         let mut pubkeys = Vec::new();
         for pk in &epoch.public_keys {
             pubkeys.push(PublicKey::from(pk.unwrap()));
         }
 
         // Calculate the hash from our to_bytes function
-        let epoch_bytes = EpochBlock::new(epoch.index.unwrap(), epoch.maximum_non_signers, pubkeys)
+        let epoch_bytes = EpochBlock::new(previous_epoch_hash, epoch.index.unwrap(), epoch.maximum_non_signers, pubkeys)
             .encode_to_bytes()
             .unwrap();
-        let (hash, _) = COMPOSITE_HASH_TO_G1
+        let (hash, xof_hash, _) = COMPOSITE_HASH_TO_G1
             .hash_with_attempt(SIG_DOMAIN, &epoch_bytes, &[])
             .unwrap();
 
-        hash
+        (hash, xof_hash)
     }
 }
 

--- a/crates/epoch-snark/src/gadgets/single_update.rs
+++ b/crates/epoch-snark/src/gadgets/single_update.rs
@@ -7,9 +7,9 @@ use r1cs_std::{
 };
 
 use super::{constrain_bool, EpochData};
+use crate::encoding::PREVIOUS_EPOCH_HASH_BITS;
 use bls_gadgets::BlsVerifyGadget;
 use tracing::{span, Level};
-use crate::encoding::PREVIOUS_EPOCH_HASH_BITS;
 
 // Instantiate the BLS Verification gadget
 type BlsGadget = BlsVerifyGadget<Bls12_377, Fr, PairingGadget>;

--- a/crates/epoch-snark/src/lib.rs
+++ b/crates/epoch-snark/src/lib.rs
@@ -25,7 +25,7 @@ mod api;
 pub use api::*;
 
 mod encoding;
-pub use encoding::EncodingError;
+pub use encoding::{EncodingError, PREVIOUS_EPOCH_HASH_BITS};
 
 mod epoch_block;
 pub use epoch_block::{EpochBlock, EpochTransition};

--- a/crates/epoch-snark/tests/fixtures.rs
+++ b/crates/epoch-snark/tests/fixtures.rs
@@ -22,7 +22,12 @@ pub fn generate_test_data(
         .iter()
         .map(|pk| PublicKey::from(*pk))
         .collect::<Vec<_>>();
-    let first_epoch = generate_block(&[0; PREVIOUS_EPOCH_HASH_BITS/8], 0, faults, &initial_pubkeys);
+    let first_epoch = generate_block(
+        &[0; PREVIOUS_EPOCH_HASH_BITS / 8],
+        0,
+        faults,
+        &initial_pubkeys,
+    );
     let (_, first_epoch_xof_hash) = first_epoch.hash_to_g1().unwrap();
 
     // Generate keys for the validators of each epoch
@@ -41,7 +46,7 @@ pub fn generate_test_data(
     let mut previous_xof_hash = first_epoch_xof_hash;
     let mut transitions = vec![];
     for (i, signers_epoch) in signers.iter().enumerate() {
-        let block: EpochBlock = generate_block(&previous_xof_hash,i + 1, faults, &pubkeys[i]);
+        let block: EpochBlock = generate_block(&previous_xof_hash, i + 1, faults, &pubkeys[i]);
         let (hash, xof_hash) = block.hash_to_g1().unwrap();
         previous_xof_hash = xof_hash;
 
@@ -70,7 +75,12 @@ pub fn generate_test_data(
     (first_epoch, transitions, last_epoch)
 }
 
-fn generate_block(previous_epoch_hash: &[u8], index: usize, non_signers: usize, pubkeys: &[PublicKey]) -> EpochBlock {
+fn generate_block(
+    previous_epoch_hash: &[u8],
+    index: usize,
+    non_signers: usize,
+    pubkeys: &[PublicKey],
+) -> EpochBlock {
     EpochBlock {
         previous_epoch_hash: previous_epoch_hash.to_vec(),
         index: index as u16,


### PR DESCRIPTION
### Description

This prevents the future committee attack discovered by @psivesely.

TODO:
- [ ] Add arbitrary randomness. cc @psivesely to finalize the design. The current thinking is to take the 
- [ ] Integrate into celo-bls-go.
- [ ] Integrate into celo-blockchain. cc @lucasege @asaj for the next milestone. This requires that when signing an epoch snark data, we must have access to the previous epoch data. This means keeping track of previous epoch hashes, so it's not a trivial change. We also require access to the current beacon.