### PR TITLE
Implement CIP22 padding

### DIFF
--- a/crates/bls-snark-sys/src/snark/epoch_block.rs
+++ b/crates/bls-snark-sys/src/snark/epoch_block.rs
@@ -19,6 +19,7 @@ pub extern "C" fn encode_epoch_block_to_bytes_cip22(
     in_epoch_entropy: *const u8,
     in_parent_entropy: *const u8,
     in_maximum_non_signers: c_uint,
+    in_maximum_validators: c_uint,
     in_added_public_keys: *const *const PublicKey,
     in_added_public_keys_len: c_int,
     out_bytes: *mut *mut u8,
@@ -43,6 +44,7 @@ pub extern "C" fn encode_epoch_block_to_bytes_cip22(
             epoch_entropy,
             parent_entropy,
             in_maximum_non_signers as u32,
+            in_maximum_validators as usize,
             added_public_keys,
         );
         let (mut encoded_inner, mut encoded_extra_data) =
@@ -85,6 +87,7 @@ pub extern "C" fn encode_epoch_block_to_bytes(
             None,
             None,
             in_maximum_non_signers as u32,
+            added_public_keys.len(),
             added_public_keys,
         );
         let mut encoded = epoch_block.encode_to_bytes()?;
@@ -114,6 +117,8 @@ pub struct EpochBlockFFI {
     pub pubkeys_num: usize,
     /// Maximum number of non signers for that epoch
     pub maximum_non_signers: u32,
+    /// Maximum number of validators
+    pub maximum_validators: usize,
 }
 
 impl TryFrom<&EpochBlockFFI> for EpochBlock {
@@ -128,6 +133,7 @@ impl TryFrom<&EpochBlockFFI> for EpochBlock {
             epoch_entropy,
             parent_entropy,
             maximum_non_signers: src.maximum_non_signers,
+            maximum_validators: src.maximum_validators,
             new_public_keys: pubkeys,
         })
     }
@@ -223,6 +229,7 @@ mod tests {
             epoch_entropy,
             parent_entropy,
             maximum_non_signers: 19,
+            maximum_validators: pubkeys.len(),
             new_public_keys: pubkeys,
         };
         let src = block;
@@ -232,6 +239,7 @@ mod tests {
             epoch_entropy: &src.epoch_entropy.as_ref().unwrap()[0],
             parent_entropy: &src.parent_entropy.as_ref().unwrap()[0],
             maximum_non_signers: src.maximum_non_signers,
+            maximum_validators: src.new_public_keys.len(),
             pubkeys_num: src.new_public_keys.len(),
             pubkeys: &serialized_pubkeys[0] as *const u8,
         };
@@ -250,6 +258,7 @@ mod tests {
             epoch_entropy,
             parent_entropy,
             maximum_non_signers: 19,
+            maximum_validators: pubkeys.len(),
             new_public_keys: pubkeys,
         };
         let src = block;
@@ -259,6 +268,7 @@ mod tests {
             epoch_entropy: std::ptr::null(),
             parent_entropy: std::ptr::null(),
             maximum_non_signers: src.maximum_non_signers,
+            maximum_validators: src.new_public_keys.len(),
             pubkeys_num: src.new_public_keys.len(),
             pubkeys: &serialized_pubkeys[0] as *const u8,
         };

--- a/crates/bls-snark-sys/src/snark/mod.rs
+++ b/crates/bls-snark-sys/src/snark/mod.rs
@@ -69,6 +69,7 @@ mod tests {
             parent_entropy: std::ptr::null(),
             maximum_non_signers: 1,
             pubkeys_num: 4,
+            maximum_validators: 4,
             pubkeys: &first_pubkeys[0] as *const u8,
         };
 
@@ -78,6 +79,7 @@ mod tests {
             parent_entropy: std::ptr::null(),
             maximum_non_signers: 1,
             pubkeys_num: 4,
+            maximum_validators: 4,
             pubkeys: &last_pubkeys[0] as *const u8,
         };
 
@@ -141,6 +143,7 @@ mod tests {
             parent_entropy: &first_parent_entropy[0] as *const u8,
             maximum_non_signers: 1,
             pubkeys_num: 4,
+            maximum_validators: 4,
             pubkeys: &first_pubkeys[0] as *const u8,
         };
 
@@ -153,6 +156,7 @@ mod tests {
             parent_entropy: &last_parent_entropy[0] as *const u8,
             maximum_non_signers: 1,
             pubkeys_num: 4,
+            maximum_validators: 4,
             pubkeys: &last_pubkeys[0] as *const u8,
         };
 

--- a/crates/epoch-snark/src/encoding.rs
+++ b/crates/epoch-snark/src/encoding.rs
@@ -1,6 +1,6 @@
 use algebra::{
     bls12_377::{Fq, FqParameters},
-    FpParameters, PrimeField, ProjectiveCurve, ToBytes,
+    FpParameters, PrimeField, ProjectiveCurve, ToBytes, Zero,
 };
 use bls_crypto::{BLSError, PublicKey};
 use bls_gadgets::utils::bytes_le_to_bits_be;
@@ -29,8 +29,9 @@ pub fn encode_public_key(public_key: &PublicKey) -> Result<Vec<bool>, EncodingEr
     let y_c0_big = y.c0.into_repr();
     let y_c1_big = y.c1.into_repr();
 
+    let zero = Fq::zero().into_repr();
     let half = Fq::modulus_minus_one_div_two();
-    let is_over_half = y_c1_big > half || (y_c1_big == half && y_c0_big > half);
+    let is_over_half = y_c1_big > half || (y_c1_big == zero && y_c0_big > half);
 
     let mut bits = vec![];
     let mut x_bytes_c0 = vec![];

--- a/crates/epoch-snark/src/gadgets/epoch_data.rs
+++ b/crates/epoch-snark/src/gadgets/epoch_data.rs
@@ -339,6 +339,7 @@ mod tests {
             epoch.epoch_entropy.as_ref().map(|v| v.to_vec()),
             epoch.parent_entropy.as_ref().map(|v| v.to_vec()),
             epoch.maximum_non_signers,
+            pubkeys.len(),
             pubkeys,
         )
         .encode_inner_to_bytes_cip22()
@@ -389,6 +390,7 @@ mod tests {
             epoch.epoch_entropy.as_ref().map(|v| v.to_vec()),
             epoch.parent_entropy.as_ref().map(|v| v.to_vec()),
             epoch.maximum_non_signers,
+            pubkeys.len(),
             pubkeys.clone(),
         )
         .encode_to_bits_cip22()
@@ -400,6 +402,7 @@ mod tests {
             epoch.epoch_entropy.as_ref().map(|v| v.to_vec()),
             epoch.parent_entropy.as_ref().map(|v| v.to_vec()),
             epoch.maximum_non_signers,
+            pubkeys.len(),
             pubkeys,
         )
         .encode_to_bits_with_aggregated_pk_cip22()

--- a/crates/epoch-snark/src/gadgets/epochs.rs
+++ b/crates/epoch-snark/src/gadgets/epochs.rs
@@ -334,6 +334,7 @@ mod tests {
                 data.epoch_entropy.clone(),
                 data.parent_entropy.clone(),
                 data.maximum_non_signers,
+                data.public_keys.len(),
                 data.public_keys
                     .iter()
                     .map(|p| PublicKey::from(p.unwrap()))

--- a/crates/epoch-snark/src/gadgets/mod.rs
+++ b/crates/epoch-snark/src/gadgets/mod.rs
@@ -54,6 +54,7 @@ pub mod test_helpers {
             epoch.epoch_entropy.as_ref().map(|v| v.to_vec()),
             epoch.parent_entropy.as_ref().map(|v| v.to_vec()),
             epoch.maximum_non_signers,
+            pubkeys.len(),
             pubkeys,
         )
         .encode_inner_to_bytes_cip22()

--- a/crates/epoch-snark/tests/fixtures.rs
+++ b/crates/epoch-snark/tests/fixtures.rs
@@ -27,6 +27,7 @@ pub fn generate_test_data(
         &[1u8; EpochBlock::ENTROPY_BYTES],
         &[2u8; EpochBlock::ENTROPY_BYTES],
         faults,
+        num_validators,
         &initial_pubkeys,
     );
 
@@ -50,6 +51,7 @@ pub fn generate_test_data(
             &[(i + 2) as u8; EpochBlock::ENTROPY_BYTES],
             &[(i + 1) as u8; EpochBlock::ENTROPY_BYTES],
             faults,
+            num_validators,
             &pubkeys[i],
         );
         let hash = block.hash_to_g1_cip22().unwrap();
@@ -84,6 +86,7 @@ fn generate_block(
     epoch_entropy: &[u8],
     parent_entropy: &[u8],
     non_signers: usize,
+    max_validators: usize,
     pubkeys: &[PublicKey],
 ) -> EpochBlock {
     EpochBlock {
@@ -91,6 +94,7 @@ fn generate_block(
         epoch_entropy: Some(epoch_entropy.to_vec()),
         parent_entropy: Some(parent_entropy.to_vec()),
         maximum_non_signers: non_signers as u32,
+        maximum_validators: max_validators,
         new_public_keys: pubkeys.to_vec(),
     }
 }


### PR DESCRIPTION
### Description

This PR adds support for padding the validator set by passing another maximum validators parameter.
This is almost 100% based on @lucasege's work.

### Drive-by change

We had a bug in `encode_public_key` where it checks `c1 == half` instead of the updated `c1 == 0` as mentioned in https://github.com/celo-org/celo-bls-snark-rs/issues/149.

### Tested

Tests on the encoding.