### PR TITLE
Add tracing for tests

### DIFF
--- a/crates/bls-gadgets/Cargo.toml
+++ b/crates/bls-gadgets/Cargo.toml
@@ -17,13 +17,13 @@ crypto-primitives = { git = "https://github.com/celo-org/zexe", default-features
 rand_xorshift = { version = "0.2", optional = true }
 rand = { version = "0.7" , optional = true }
 tracing = "0.1.13"
+tracing-subscriber = { version = "0.2" }
 
 [dev-dependencies]
 rand_xorshift = { version = "0.2" }
 rand = { version = "0.7" }
 groth16 = { git = "https://github.com/celo-org/zexe" }
 bls-crypto = { path = "../bls-crypto", default-features = false, features = ["test-helpers"] }
-tracing-subscriber = { version = "0.2" }
 
 [features]
 default = []

--- a/crates/bls-gadgets/src/bitmap.rs
+++ b/crates/bls-gadgets/src/bitmap.rs
@@ -143,6 +143,7 @@ mod tests {
         assert!(verify_proof(&pvk, &proof, &[]).unwrap());
     }
 
+    #[tracing::instrument(target = "r1cs")]
     fn cs_enforce_value(bitmap: &[bool], max_number: u64, is_one: bool) -> ConstraintSystemRef<Fq> {
         let cs = ConstraintSystem::<Fq>::new_ref();
         let bitmap = bitmap

--- a/crates/bls-gadgets/src/bitmap.rs
+++ b/crates/bls-gadgets/src/bitmap.rs
@@ -13,6 +13,7 @@ pub trait Bitmap<F: PrimeField> {
 }
 
 impl<F: PrimeField> Bitmap<F> for [Boolean<F>] {
+    #[tracing::instrument(target = "r1cs")]
     fn enforce_maximum_occurrences_in_bitmap(
         &self,
         max_occurrences: &FpVar<F>,
@@ -73,7 +74,7 @@ impl<F: PrimeField> Bitmap<F> for [Boolean<F>] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::test_helpers::print_unsatisfied_constraints;
+    use crate::utils::test_helpers::{print_unsatisfied_constraints, run_profile_constraints};
 
     use algebra::{
         bls12_377::{Fq, Fr},
@@ -161,31 +162,39 @@ mod tests {
 
         #[test]
         fn one_zero_allowed() {
-            assert!(cs_enforce_value(&[false], 1, false).is_satisfied().unwrap());
+            run_profile_constraints(|| {
+                let cs = cs_enforce_value(&[false], 1, false);
+                print_unsatisfied_constraints(cs.clone());
+                assert!(cs.is_satisfied().unwrap());
+            });
         }
 
         #[test]
         fn no_zeros_allowed() {
-            assert!(!cs_enforce_value(&[false], 0, false).is_satisfied().unwrap());
+            run_profile_constraints(|| {
+                let cs = cs_enforce_value(&[false], 0, false);
+                print_unsatisfied_constraints(cs.clone());
+                assert!(!cs.is_satisfied().unwrap());
+            });
         }
 
         #[test]
 
         fn three_zeros_allowed() {
-            assert!(
-                cs_enforce_value(&[false, true, true, false, false], 3, false)
-                    .is_satisfied()
-                    .unwrap()
-            );
+            run_profile_constraints(|| {
+                let cs = cs_enforce_value(&[false, true, true, false, false], 3, false);
+                print_unsatisfied_constraints(cs.clone());
+                assert!(cs.is_satisfied().unwrap());
+            });
         }
 
         #[test]
         fn four_zeros_not_allowed() {
-            assert!(
-                !cs_enforce_value(&[false, false, true, false, false], 3, false)
-                    .is_satisfied()
-                    .unwrap()
-            );
+            run_profile_constraints(|| {
+                let cs = cs_enforce_value(&[false, false, true, false, false], 3, false);
+                print_unsatisfied_constraints(cs.clone());
+                assert!(!cs.is_satisfied().unwrap());
+            });
         }
     }
 
@@ -194,26 +203,38 @@ mod tests {
 
         #[test]
         fn one_one_allowed() {
-            assert!(cs_enforce_value(&[true], 1, true).is_satisfied().unwrap());
+            run_profile_constraints(|| {
+                let cs = cs_enforce_value(&[true], 1, true);
+                print_unsatisfied_constraints(cs.clone());
+                assert!(cs.is_satisfied().unwrap());
+            });
         }
 
         #[test]
         fn no_ones_allowed() {
-            assert!(!cs_enforce_value(&[true], 0, true).is_satisfied().unwrap());
+            run_profile_constraints(|| {
+                let cs = cs_enforce_value(&[true], 0, true);
+                print_unsatisfied_constraints(cs.clone());
+                assert!(!cs.is_satisfied().unwrap());
+            });
         }
 
         #[test]
         fn three_ones_allowed() {
-            assert!(cs_enforce_value(&[false, true, true, true, false], 3, true)
-                .is_satisfied()
-                .unwrap());
+            run_profile_constraints(|| {
+                let cs = cs_enforce_value(&[false, true, true, true, false], 3, true);
+                print_unsatisfied_constraints(cs.clone());
+                assert!(cs.is_satisfied().unwrap());
+            });
         }
 
         #[test]
         fn four_ones_not_allowed() {
-            assert!(!cs_enforce_value(&[true, true, true, true, false], 3, true)
-                .is_satisfied()
-                .unwrap());
+            run_profile_constraints(|| {
+                let cs = cs_enforce_value(&[true, true, true, true, false], 3, true);
+                print_unsatisfied_constraints(cs.clone());
+                assert!(!cs.is_satisfied().unwrap());
+            });
         }
     }
 }

--- a/crates/bls-gadgets/src/bls.rs
+++ b/crates/bls-gadgets/src/bls.rs
@@ -37,6 +37,7 @@ where
     ///
     /// The verification equation can be found in pg.11 from
     /// https://eprint.iacr.org/2018/483.pdf: "Multi-Signature Verification"
+    #[tracing::instrument(target = "r1cs")]
     pub fn verify(
         pub_keys: &[P::G2Var],
         signed_bitmap: &[Boolean<F>],
@@ -73,6 +74,7 @@ where
     ///
     /// The verification equation can be found in pg.11 from
     /// https://eprint.iacr.org/2018/483.pdf: "Batch verification"
+    #[tracing::instrument(target = "r1cs")]
     pub fn batch_verify(
         aggregated_pub_keys: &[P::G2Var],
         message_hashes: &[P::G1Var],
@@ -96,6 +98,7 @@ where
     }
 
     /// Batch verification against prepared messages
+    #[tracing::instrument(target = "r1cs")]
     pub fn batch_verify_prepared(
         prepared_aggregated_pub_keys: &[P::G2PreparedVar],
         prepared_message_hashes: &[P::G1PreparedVar],
@@ -123,6 +126,7 @@ where
     ///
     /// # Panics
     /// If signed_bitmap length != pub_keys length
+    #[tracing::instrument(target = "r1cs")]
     pub fn enforce_aggregated_pubkeys(
         pub_keys: &[P::G2Var],
         signed_bitmap: &[Boolean<F>],
@@ -142,6 +146,7 @@ where
 
     /// Returns a gadget which checks that an aggregate pubkey is correctly calculated
     /// by the sum of the pub keys
+    #[tracing::instrument(target = "r1cs")]
     pub fn enforce_aggregated_all_pubkeys(
         pub_keys: &[P::G2Var],
     ) -> Result<P::G2Var, SynthesisError> {
@@ -160,6 +165,7 @@ where
     ///
     /// # Panics
     /// If signed_bitmap length != pub_keys length (due to internal call to `enforced_aggregated_pubkeys`)
+    #[tracing::instrument(target = "r1cs")]
     pub fn enforce_bitmap(
         pub_keys: &[P::G2Var],
         signed_bitmap: &[Boolean<F>],
@@ -176,6 +182,7 @@ where
 
     /// Verifying BLS signatures requires preparing a G1 Signature and
     /// preparing a negated G2 generator
+    #[tracing::instrument(target = "r1cs")]
     fn prepare_signature_neg_generator(
         signature: &P::G1Var,
     ) -> Result<(P::G1PreparedVar, P::G2PreparedVar), SynthesisError> {
@@ -200,6 +207,7 @@ where
     ///
     /// Each G1 element is paired with the corresponding G2 element.
     /// Fails if the 2 slices have different lengths.
+    #[tracing::instrument(target = "r1cs")]
     fn enforce_bls_equation(
         g1: &[P::G1PreparedVar],
         g2: &[P::G2PreparedVar],
@@ -231,6 +239,7 @@ mod verify_one_message {
     };
 
     // converts the arguments to constraints and checks them against the `verify` function
+    #[tracing::instrument(target = "r1cs")]
     fn cs_verify<E: PairingEngine, F: PrimeField, P: PairingVar<E, F>>(
         message_hash: E::G1Projective,
         pub_keys: &[E::G2Projective],
@@ -287,6 +296,7 @@ mod verify_one_message {
     fn batch_verify_ok() {
         run_profile_constraints(batch_verify_ok_inner);
     }
+    #[tracing::instrument(target = "r1cs")]
     fn batch_verify_ok_inner() {
         // generate 5 (aggregate sigs, message hash pairs)
         // verify them all in 1 call
@@ -357,6 +367,7 @@ mod verify_one_message {
         run_profile_constraints(one_signature_ok_inner);
     }
     // Verifies signatures over BLS12_377 with Sw6 field (384 bits).
+    #[tracing::instrument(target = "r1cs")]
     fn one_signature_ok_inner() {
         let (secret_key, pub_key) = keygen::<Bls12_377>();
         let rng = &mut rng();
@@ -392,6 +403,7 @@ mod verify_one_message {
     fn multiple_signatures_ok() {
         run_profile_constraints(multiple_signatures_ok_inner);
     }
+    #[tracing::instrument(target = "r1cs")]
     fn multiple_signatures_ok_inner() {
         let rng = &mut rng();
         let message_hash = G1Projective::rand(rng);
@@ -448,6 +460,7 @@ mod verify_one_message {
     fn zero_succeeds() {
         run_profile_constraints(zero_succeeds_inner);
     }
+    #[tracing::instrument(target = "r1cs")]
     fn zero_succeeds_inner() {
         let rng = &mut rng();
         let message_hash = G1Projective::rand(rng);
@@ -476,6 +489,7 @@ mod verify_one_message {
     fn doubling_succeeds() {
         run_profile_constraints(doubling_succeeds_inner);
     }
+    #[tracing::instrument(target = "r1cs")]
     fn doubling_succeeds_inner() {
         let rng = &mut rng();
         let message_hash = G1Projective::rand(rng);

--- a/crates/bls-gadgets/src/bls.rs
+++ b/crates/bls-gadgets/src/bls.rs
@@ -215,7 +215,7 @@ where
 #[cfg(test)]
 mod verify_one_message {
     use super::*;
-    use crate::utils::test_helpers::print_unsatisfied_constraints;
+    use crate::utils::test_helpers::{print_unsatisfied_constraints, run_profile_constraints};
     use bls_crypto::test_helpers::*;
 
     use algebra::{
@@ -285,6 +285,9 @@ mod verify_one_message {
 
     #[test]
     fn batch_verify_ok() {
+        run_profile_constraints(batch_verify_ok_inner);
+    }
+    fn batch_verify_ok_inner() {
         // generate 5 (aggregate sigs, message hash pairs)
         // verify them all in 1 call
         let batch_size = 5;
@@ -350,8 +353,11 @@ mod verify_one_message {
     }
 
     #[test]
-    // Verifies signatures over BLS12_377 with Sw6 field (384 bits).
     fn one_signature_ok() {
+        run_profile_constraints(one_signature_ok_inner);
+    }
+    // Verifies signatures over BLS12_377 with Sw6 field (384 bits).
+    fn one_signature_ok_inner() {
         let (secret_key, pub_key) = keygen::<Bls12_377>();
         let rng = &mut rng();
         let message_hash = G1Projective::rand(rng);
@@ -384,6 +390,9 @@ mod verify_one_message {
 
     #[test]
     fn multiple_signatures_ok() {
+        run_profile_constraints(multiple_signatures_ok_inner);
+    }
+    fn multiple_signatures_ok_inner() {
         let rng = &mut rng();
         let message_hash = G1Projective::rand(rng);
         let (sk, pk) = keygen::<Bls12_377>();
@@ -437,6 +446,9 @@ mod verify_one_message {
 
     #[test]
     fn zero_succeeds() {
+        run_profile_constraints(zero_succeeds_inner);
+    }
+    fn zero_succeeds_inner() {
         let rng = &mut rng();
         let message_hash = G1Projective::rand(rng);
         let generator = G2Projective::prime_subgroup_generator();
@@ -462,6 +474,9 @@ mod verify_one_message {
 
     #[test]
     fn doubling_succeeds() {
+        run_profile_constraints(doubling_succeeds_inner);
+    }
+    fn doubling_succeeds_inner() {
         let rng = &mut rng();
         let message_hash = G1Projective::rand(rng);
 

--- a/crates/bls-gadgets/src/hash_to_group.rs
+++ b/crates/bls-gadgets/src/hash_to_group.rs
@@ -347,7 +347,7 @@ impl<P: Bls12Parameters> HashToGroupGadget<P, Bls12_377_Fq> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::utils::test_helpers::print_unsatisfied_constraints;
+    use crate::utils::test_helpers::{print_unsatisfied_constraints, run_profile_constraints};
 
     use algebra::bls12_377;
     use bls_crypto::hash_to_curve::try_and_increment_cip22::COMPOSITE_HASH_TO_G1_CIP22;
@@ -357,6 +357,9 @@ mod test {
 
     #[test]
     fn test_hash_to_group() {
+        run_profile_constraints(test_hash_to_group_inner);
+    }
+    fn test_hash_to_group_inner() {
         let mut rng = thread_rng();
         // test for various input sizes
         for length in &[10, 25, 50, 100, 200, 300] {

--- a/crates/bls-gadgets/src/hash_to_group.rs
+++ b/crates/bls-gadgets/src/hash_to_group.rs
@@ -101,6 +101,7 @@ impl HashToGroupGadget<Bls12_377_Parameters, Bls12_377_Fq> {
     /// so that they can be used to verify the correct calculation of the XOF from
     /// the CRH in a separate proof.
     #[allow(clippy::type_complexity)]
+    #[tracing::instrument(target = "r1cs")]
     pub fn enforce_hash_to_group(
         counter: UInt8<Bls12_377_Fq>,
         message: &[UInt8<Bls12_377_Fq>],
@@ -184,6 +185,7 @@ impl HashToGroupGadget<Bls12_377_Parameters, Bls12_377_Fq> {
 /// # Panics
 ///
 /// If the provided hash_length is not a multiple of 256.
+#[tracing::instrument(target = "r1cs")]
 pub fn hash_to_bits<F: PrimeField>(
     message: &[Boolean<F>],
     hash_length: u16,
@@ -374,6 +376,7 @@ mod test {
         }
     }
 
+    #[tracing::instrument(target = "r1cs")]
     fn hash_to_group(input: &[u8], extra_input: &[u8]) {
         let try_and_increment = &*COMPOSITE_HASH_TO_G1_CIP22;
         let (expected_hash, attempt) = try_and_increment

--- a/crates/bls-gadgets/src/utils.rs
+++ b/crates/bls-gadgets/src/utils.rs
@@ -56,7 +56,15 @@ pub fn bytes_le_to_bits_le(bytes: &[u8], bits_to_take: usize) -> Vec<bool> {
 #[cfg(any(test, feature = "test-helpers"))]
 pub mod test_helpers {
     use algebra::PrimeField;
-    use r1cs_core::ConstraintSystemRef;
+    use r1cs_core::{ConstraintLayer, ConstraintSystemRef};
+    use tracing_subscriber::layer::SubscriberExt;
+
+    pub fn run_profile_constraints<T>(f: impl FnOnce() -> T) -> T {
+        let mut layer = ConstraintLayer::default();
+        layer.mode = r1cs_core::TracingMode::OnlyConstraints;
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        tracing::subscriber::with_default(subscriber, f)
+    }
 
     pub fn print_unsatisfied_constraints<F: PrimeField>(cs: ConstraintSystemRef<F>) {
         if !cs.is_satisfied().unwrap() {

--- a/crates/bls-gadgets/src/y_to_bit.rs
+++ b/crates/bls-gadgets/src/y_to_bit.rs
@@ -84,6 +84,7 @@ impl YToBitGadget<Bls12_377_Parameters> for G2Var<Bls12_377_Parameters> {
 }
 
 impl<F: PrimeField> FpUtils<F> for FpVar<F> {
+    #[tracing::instrument(target = "r1cs")]
     fn is_eq_zero(&self) -> Result<Boolean<F>, SynthesisError> {
         match self {
             Self::Constant(_) => Ok(Boolean::constant(self.value()? == F::zero())),
@@ -122,6 +123,7 @@ impl<F: PrimeField> FpUtils<F> for FpVar<F> {
         }
     }
 
+    #[tracing::instrument(target = "r1cs")]
     fn normalize(&self) -> Result<Boolean<F>, SynthesisError> {
         let half = F::from_repr(F::modulus_minus_one_div_two()).get()?;
         match self {
@@ -184,6 +186,7 @@ mod test {
     fn test_y_to_bit_g1() {
         run_profile_constraints(test_y_to_bit_g1_inner);
     }
+    #[tracing::instrument(target = "r1cs")]
     fn test_y_to_bit_g1_inner() {
         let half = Fp::from_repr(Fp::modulus_minus_one_div_two()).unwrap();
         let rng = &mut rand::thread_rng();

--- a/crates/bls-gadgets/src/y_to_bit.rs
+++ b/crates/bls-gadgets/src/y_to_bit.rs
@@ -160,7 +160,7 @@ impl<F: PrimeField> FpUtils<F> for FpVar<F> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::utils::test_helpers::print_unsatisfied_constraints;
+    use crate::utils::test_helpers::{print_unsatisfied_constraints, run_profile_constraints};
 
     use algebra::{
         bls12_377::{G1Projective, G2Affine, G2Projective, Parameters},
@@ -182,6 +182,9 @@ mod test {
 
     #[test]
     fn test_y_to_bit_g1() {
+        run_profile_constraints(test_y_to_bit_g1_inner);
+    }
+    fn test_y_to_bit_g1_inner() {
         let half = Fp::from_repr(Fp::modulus_minus_one_div_two()).unwrap();
         let rng = &mut rand::thread_rng();
 
@@ -210,6 +213,9 @@ mod test {
 
     #[test]
     fn test_y_to_bit_g2() {
+        run_profile_constraints(test_y_to_bit_g2_inner);
+    }
+    fn test_y_to_bit_g2_inner() {
         let half = Fp::from_repr(Fp::modulus_minus_one_div_two()).unwrap();
         let zero = <Parameters as Bls12Parameters>::Fp::zero();
         let rng = &mut rand::thread_rng();
@@ -290,33 +296,43 @@ mod test {
     // Check points at the edge - c1 == half.
     #[test]
     fn test_y_to_bit_g2_c1_is_half() {
-        let half = <<Parameters as Bls12Parameters>::Fp as PrimeField>::modulus_minus_one_div_two();
-        test_y_to_bit_g2_edge(half);
+        run_profile_constraints(|| {
+            let half =
+                <<Parameters as Bls12Parameters>::Fp as PrimeField>::modulus_minus_one_div_two();
+            test_y_to_bit_g2_edge(half);
+        });
     }
 
     // Check points at the edge - c1 == 0.
     #[test]
     fn test_y_to_bit_g2_c1_is_zero() {
-        let zero = <Parameters as Bls12Parameters>::Fp::zero();
-        test_y_to_bit_g2_edge(zero.into_repr());
+        run_profile_constraints(|| {
+            let zero = <Parameters as Bls12Parameters>::Fp::zero();
+            test_y_to_bit_g2_edge(zero.into_repr());
+        });
     }
 
     // Check points at the edge - c1 == p-1.
     #[test]
     fn test_y_to_bit_g2_c1_is_p_minus_1() {
-        let half = <<Parameters as Bls12Parameters>::Fp as PrimeField>::modulus_minus_one_div_two();
-        let mut p_minus_one = half;
-        p_minus_one.mul2();
-        test_y_to_bit_g2_edge(p_minus_one);
+        run_profile_constraints(|| {
+            let half =
+                <<Parameters as Bls12Parameters>::Fp as PrimeField>::modulus_minus_one_div_two();
+            let mut p_minus_one = half;
+            p_minus_one.mul2();
+            test_y_to_bit_g2_edge(p_minus_one);
+        });
     }
 
     // Check points at the edge - c1 == half + 1.
     #[test]
     fn test_y_to_bit_g2_c1_is_half_plus_one() {
-        let mut half_plus_one =
-            <<Parameters as Bls12Parameters>::Fp as PrimeField>::modulus_minus_one_div_two();
-        let one = <<Parameters as Bls12Parameters>::Fp as PrimeField>::BigInt::from(1);
-        half_plus_one.add_nocarry(&one);
-        test_y_to_bit_g2_edge(half_plus_one);
+        run_profile_constraints(|| {
+            let mut half_plus_one =
+                <<Parameters as Bls12Parameters>::Fp as PrimeField>::modulus_minus_one_div_two();
+            let one = <<Parameters as Bls12Parameters>::Fp as PrimeField>::BigInt::from(1);
+            half_plus_one.add_nocarry(&one);
+            test_y_to_bit_g2_edge(half_plus_one);
+        });
     }
 }

--- a/crates/epoch-snark/src/gadgets/epoch_bits.rs
+++ b/crates/epoch-snark/src/gadgets/epoch_bits.rs
@@ -152,13 +152,19 @@ fn le_chunks(iter: &[Bool], chunk_size: u32) -> Vec<Vec<Bool>> {
 mod tests {
     use super::*;
     use crate::{epoch_block::hash_to_bits, gadgets::pack};
-    use bls_gadgets::utils::{bytes_le_to_bits_be, test_helpers::print_unsatisfied_constraints};
+    use bls_gadgets::utils::{
+        bytes_le_to_bits_be,
+        test_helpers::{print_unsatisfied_constraints, run_profile_constraints},
+    };
 
     use r1cs_core::ConstraintSystem;
     use rand::RngCore;
 
     #[test]
     fn correct_blake2_hash() {
+        run_profile_constraints(correct_blake2_hash_inner);
+    }
+    fn correct_blake2_hash_inner() {
         let rng = &mut rand::thread_rng();
         let mut first_bytes = vec![0; 32];
         rng.fill_bytes(&mut first_bytes);

--- a/crates/epoch-snark/src/gadgets/epoch_bits.rs
+++ b/crates/epoch-snark/src/gadgets/epoch_bits.rs
@@ -164,6 +164,7 @@ mod tests {
     fn correct_blake2_hash() {
         run_profile_constraints(correct_blake2_hash_inner);
     }
+    #[tracing::instrument(target = "r1cs")]
     fn correct_blake2_hash_inner() {
         let rng = &mut rand::thread_rng();
         let mut first_bytes = vec![0; 32];

--- a/crates/epoch-snark/src/gadgets/epoch_data.rs
+++ b/crates/epoch-snark/src/gadgets/epoch_data.rs
@@ -97,6 +97,7 @@ impl EpochData<Bls12_377> {
     /// Ensures that the epoch's index is equal to `previous_index + 1`. Enforces that
     /// the epoch's G1 hash is correctly calculated, and also provides auxiliary data for
     /// verifying the CRH->XOF hash outside of BW6_761.
+    #[tracing::instrument(target = "r1cs")]
     pub fn constrain(
         &self,
         previous_index: &FrVar,
@@ -207,6 +208,7 @@ impl EpochData<Bls12_377> {
     }
 
     /// Enforces that `index = previous_index + 1`
+    #[tracing::instrument(target = "r1cs")]
     fn enforce_next_epoch(previous_index: &FrVar, index: &FrVar) -> Result<(), SynthesisError> {
         trace!("enforcing next epoch");
         let previous_plus_one = previous_index + Fr::one();
@@ -219,6 +221,7 @@ impl EpochData<Bls12_377> {
 
     /// Packs the provided bits in U8s, and calculates the hash and the counter
     /// Also returns the auxiliary CRH and XOF bits for potential compression from consumers
+    #[tracing::instrument(target = "r1cs")]
     fn hash_bits_to_g1(
         epoch_bits: &[Bool],
         epoch_extra_data_bits: &[Bool],
@@ -300,6 +303,7 @@ mod tests {
     };
     use r1cs_core::ConstraintSystem;
 
+    #[tracing::instrument(target = "r1cs")]
     fn test_epoch(index: u16) -> EpochData<Bls12_377> {
         let rng = &mut rand::thread_rng();
         let pubkeys = (0..10)
@@ -333,6 +337,7 @@ mod tests {
     fn test_hash_epoch_to_g1() {
         run_profile_constraints(test_hash_epoch_to_g1_inner);
     }
+    #[tracing::instrument(target = "r1cs")]
     fn test_hash_epoch_to_g1_inner() {
         let epoch = test_epoch(10);
         let mut pubkeys = Vec::new();
@@ -368,6 +373,7 @@ mod tests {
     fn enforce_next_epoch() {
         run_profile_constraints(enforce_next_epoch_inner);
     }
+    #[tracing::instrument(target = "r1cs")]
     fn enforce_next_epoch_inner() {
         for (index1, index2, expected) in &[
             (0u16, 1u16, true),
@@ -390,6 +396,7 @@ mod tests {
     fn epoch_to_bits_ok() {
         run_profile_constraints(epoch_to_bits_ok_inner);
     }
+    #[tracing::instrument(target = "r1cs")]
     fn epoch_to_bits_ok_inner() {
         let epoch = test_epoch(18);
         let mut pubkeys = Vec::new();

--- a/crates/epoch-snark/src/gadgets/epoch_data.rs
+++ b/crates/epoch-snark/src/gadgets/epoch_data.rs
@@ -290,7 +290,9 @@ mod tests {
     use super::*;
     use crate::epoch_block::EpochBlock;
     use bls_crypto::PublicKey;
-    use bls_gadgets::utils::test_helpers::print_unsatisfied_constraints;
+    use bls_gadgets::utils::test_helpers::{
+        print_unsatisfied_constraints, run_profile_constraints,
+    };
 
     use algebra::{
         bls12_377::{Bls12_377, G2Projective as Bls12_377G2Projective},
@@ -317,16 +319,21 @@ mod tests {
 
     #[test]
     fn test_enforce() {
-        let epoch = test_epoch(10);
-        let cs = ConstraintSystem::<Fr>::new_ref();
-        let index = FrVar::new_witness(cs.clone(), || Ok(Fr::from(9u32))).unwrap();
-        epoch.constrain(&index, false).unwrap();
-        print_unsatisfied_constraints(cs.clone());
-        assert!(cs.is_satisfied().unwrap());
+        run_profile_constraints(|| {
+            let epoch = test_epoch(10);
+            let cs = ConstraintSystem::<Fr>::new_ref();
+            let index = FrVar::new_witness(cs.clone(), || Ok(Fr::from(9u32))).unwrap();
+            epoch.constrain(&index, false).unwrap();
+            print_unsatisfied_constraints(cs.clone());
+            assert!(cs.is_satisfied().unwrap());
+        });
     }
 
     #[test]
     fn test_hash_epoch_to_g1() {
+        run_profile_constraints(test_hash_epoch_to_g1_inner);
+    }
+    fn test_hash_epoch_to_g1_inner() {
         let epoch = test_epoch(10);
         let mut pubkeys = Vec::new();
         for pk in &epoch.public_keys {
@@ -359,6 +366,9 @@ mod tests {
 
     #[test]
     fn enforce_next_epoch() {
+        run_profile_constraints(enforce_next_epoch_inner);
+    }
+    fn enforce_next_epoch_inner() {
         for (index1, index2, expected) in &[
             (0u16, 1u16, true),
             (1, 3, false),
@@ -378,6 +388,9 @@ mod tests {
 
     #[test]
     fn epoch_to_bits_ok() {
+        run_profile_constraints(epoch_to_bits_ok_inner);
+    }
+    fn epoch_to_bits_ok_inner() {
         let epoch = test_epoch(18);
         let mut pubkeys = Vec::new();
         for pk in &epoch.public_keys {

--- a/crates/epoch-snark/src/gadgets/epochs.rs
+++ b/crates/epoch-snark/src/gadgets/epochs.rs
@@ -319,7 +319,9 @@ impl ValidatorSetUpdate<Bls12_377> {
 mod tests {
     use super::*;
     use crate::gadgets::single_update::test_helpers::generate_single_update;
-    use bls_gadgets::utils::test_helpers::print_unsatisfied_constraints;
+    use bls_gadgets::utils::test_helpers::{
+        print_unsatisfied_constraints, run_profile_constraints,
+    };
 
     use algebra::{bls12_377::G1Projective, ProjectiveCurve};
     use bls_crypto::test_helpers::{keygen_batch, keygen_mul, sign_batch, sum};
@@ -465,8 +467,11 @@ mod tests {
         }
 
         #[test]
-        #[tracing::instrument(target = "r1cs")]
         fn test_multiple_epochs() {
+            run_profile_constraints(test_multiple_epochs_inner);
+        }
+        #[tracing::instrument(target = "r1cs")]
+        fn test_multiple_epochs_inner() {
             let num_faults = 2;
             let num_epochs = 4;
             // no more than `faults` 0s exist in the bitmap
@@ -492,8 +497,11 @@ mod tests {
         }
 
         #[test]
-        #[tracing::instrument(target = "r1cs")]
         fn test_multiple_epochs_with_dummy() {
+            run_profile_constraints(test_multiple_epochs_with_dummy_inner);
+        }
+        #[tracing::instrument(target = "r1cs")]
+        fn test_multiple_epochs_with_dummy_inner() {
             let num_faults = 2;
             let num_epochs = 4;
             // no more than `faults` 0s exist in the bitmap
@@ -519,8 +527,11 @@ mod tests {
         }
 
         #[test]
-        #[tracing::instrument(target = "r1cs")]
         fn test_multiple_epochs_with_entropy() {
+            run_profile_constraints(test_multiple_epochs_with_entropy_inner);
+        }
+        #[tracing::instrument(target = "r1cs")]
+        fn test_multiple_epochs_with_entropy_inner() {
             let num_faults = 2;
             let num_epochs = 4;
             // no more than `faults` 0s exist in the bitmap
@@ -563,8 +574,11 @@ mod tests {
         }
 
         #[test]
-        #[tracing::instrument(target = "r1cs")]
         fn test_multiple_epochs_with_wrong_entropy() {
+            run_profile_constraints(test_multiple_epochs_with_wrong_entropy_inner);
+        }
+        #[tracing::instrument(target = "r1cs")]
+        fn test_multiple_epochs_with_wrong_entropy_inner() {
             let num_faults = 2;
             let num_epochs = 4;
             // no more than `faults` 0s exist in the bitmap
@@ -608,8 +622,11 @@ mod tests {
         }
 
         #[test]
-        #[tracing::instrument(target = "r1cs")]
         fn test_multiple_epochs_with_wrong_entropy_dummy() {
+            run_profile_constraints(test_multiple_epochs_with_wrong_entropy_dummy_inner);
+        }
+        #[tracing::instrument(target = "r1cs")]
+        fn test_multiple_epochs_with_wrong_entropy_dummy_inner() {
             let num_faults = 2;
             let num_epochs = 4;
             // no more than `faults` 0s exist in the bitmap
@@ -655,8 +672,11 @@ mod tests {
         }
 
         #[test]
-        #[tracing::instrument(target = "r1cs")]
         fn test_multiple_epochs_with_no_initial_entropy() {
+            run_profile_constraints(test_multiple_epochs_with_no_initial_entropy_inner);
+        }
+        #[tracing::instrument(target = "r1cs")]
+        fn test_multiple_epochs_with_no_initial_entropy_inner() {
             let num_faults = 2;
             let num_epochs = 4;
             // no more than `faults` 0s exist in the bitmap

--- a/crates/epoch-snark/src/gadgets/epochs.rs
+++ b/crates/epoch-snark/src/gadgets/epochs.rs
@@ -58,6 +58,7 @@ pub struct HashToBitsHelper<E: PairingEngine> {
 
 impl<E: PairingEngine> ValidatorSetUpdate<E> {
     /// Initializes an empty validator set update. This is used when running the trusted setup.
+    #[tracing::instrument(target = "r1cs")]
     pub fn empty(
         num_validators: usize,
         num_epochs: usize,
@@ -83,6 +84,7 @@ impl<E: PairingEngine> ValidatorSetUpdate<E> {
 impl ConstraintSynthesizer<Fr> for ValidatorSetUpdate<Bls12_377> {
     /// Enforce that the signatures over the epochs have been calculated
     /// correctly, and then compress the public inputs
+    #[tracing::instrument(target = "r1cs")]
     fn generate_constraints(self, cs: ConstraintSystemRef<Fr>) -> Result<(), SynthesisError> {
         let span = span!(Level::TRACE, "ValidatorSetUpdate");
         let _enter = span.enter();

--- a/crates/epoch-snark/src/gadgets/mod.rs
+++ b/crates/epoch-snark/src/gadgets/mod.rs
@@ -44,6 +44,7 @@ pub mod test_helpers {
     }
 
     /// Generate hashed point of epoch data without generating constraints
+    #[tracing::instrument(target = "r1cs")]
     pub fn hash_epoch(epoch: &EpochData<Bls12_377>) -> G1Projective {
         let mut pubkeys = Vec::new();
         for pk in &epoch.public_keys {
@@ -89,6 +90,7 @@ fn bytes_to_fr(cs: ConstraintSystemRef<Fr>, bytes: Option<&[u8]>) -> Result<FrVa
 }
 
 /// Returns the bit representation of the Fr element in *little-endian* ordering.
+#[tracing::instrument(target = "r1cs")]
 fn fr_to_bits(input: &FrVar, length: usize) -> Result<Vec<Bool>, SynthesisError> {
     let input = input.to_bits_le()?;
     let result = input[0..length].to_vec();
@@ -96,6 +98,7 @@ fn fr_to_bits(input: &FrVar, length: usize) -> Result<Vec<Bool>, SynthesisError>
 }
 
 /// Returns elements in big-endian order
+#[tracing::instrument(target = "r1cs")]
 fn g2_to_bits(input: &G2Var) -> Result<Vec<Bool>, SynthesisError> {
     let mut x_0 = input.x.c0.to_bits_le()?;
     let mut x_1 = input.x.c1.to_bits_le()?;
@@ -110,6 +113,7 @@ fn g2_to_bits(input: &G2Var) -> Result<Vec<Bool>, SynthesisError> {
 }
 
 /// Constrains booleans to be witness variables
+#[tracing::instrument(target = "r1cs")]
 fn constrain_bool<F: PrimeField>(
     input: &[Option<bool>],
     cs: ConstraintSystemRef<F>,

--- a/crates/epoch-snark/src/gadgets/pack.rs
+++ b/crates/epoch-snark/src/gadgets/pack.rs
@@ -11,6 +11,7 @@ impl MultipackGadget {
     /// Packs the provided boolean constraints to a vector of field element gadgets of
     /// `element_size` each. If `should_alloc_input` is set to true, then the allocations
     /// will be made as public inputs.
+    #[tracing::instrument(target = "r1cs")]
     pub fn pack<F: PrimeField, Fp: FpParameters>(
         bits: &[Boolean<F>],
         element_size: usize,

--- a/crates/epoch-snark/src/gadgets/single_update.rs
+++ b/crates/epoch-snark/src/gadgets/single_update.rs
@@ -188,7 +188,9 @@ pub mod test_helpers {
 mod tests {
     use super::{test_helpers::generate_single_update, *};
     use crate::gadgets::bytes_to_fr;
-    use bls_gadgets::utils::test_helpers::print_unsatisfied_constraints;
+    use bls_gadgets::utils::test_helpers::{
+        print_unsatisfied_constraints, run_profile_constraints,
+    };
 
     use algebra::{BigInteger, PrimeField, UniformRand};
     use bls_gadgets::utils::bytes_le_to_bits_le;
@@ -208,49 +210,55 @@ mod tests {
 
     #[test]
     fn test_enough_pubkeys_for_update() {
-        let cs = ConstraintSystem::<Fr>::new_ref();
+        run_profile_constraints(|| {
+            let cs = ConstraintSystem::<Fr>::new_ref();
 
-        single_update_enforce(
-            cs.clone(),
-            5,
-            5,
-            1,
-            None,
-            2,
-            1,
-            &[true, true, true, true, false],
-        )
-        .unwrap();
+            single_update_enforce(
+                cs.clone(),
+                5,
+                5,
+                1,
+                None,
+                2,
+                1,
+                &[true, true, true, true, false],
+            )
+            .unwrap();
 
-        print_unsatisfied_constraints(cs.clone());
-        assert!(cs.is_satisfied().unwrap());
+            print_unsatisfied_constraints(cs.clone());
+            assert!(cs.is_satisfied().unwrap());
+        });
     }
 
     #[test]
     fn not_enough_pubkeys_for_update() {
-        let cs = ConstraintSystem::<Fr>::new_ref();
-        // 2 false in the bitmap when only 1 allowed
-        single_update_enforce(
-            cs.clone(),
-            5,
-            5,
-            4,
-            None,
-            5,
-            1,
-            &[true, true, false, true, false],
-        )
-        .unwrap();
+        run_profile_constraints(|| {
+            let cs = ConstraintSystem::<Fr>::new_ref();
+            // 2 false in the bitmap when only 1 allowed
+            single_update_enforce(
+                cs.clone(),
+                5,
+                5,
+                4,
+                None,
+                5,
+                1,
+                &[true, true, false, true, false],
+            )
+            .unwrap();
 
-        print_unsatisfied_constraints(cs.clone());
-        assert!(!cs.is_satisfied().unwrap());
+            print_unsatisfied_constraints(cs.clone());
+            assert!(!cs.is_satisfied().unwrap());
+        });
     }
 
     #[test]
     #[should_panic]
     fn validator_number_cannot_change() {
-        let cs = ConstraintSystem::<Fr>::new_ref();
-        single_update_enforce(cs, 5, 6, 0, None, 0, 0, &[]).unwrap();
+        run_profile_constraints(|| {
+            let cs = ConstraintSystem::<Fr>::new_ref();
+            single_update_enforce(cs, 5, 6, 0, None, 0, 0, &[]).unwrap();
+        });
     }
 
     #[cfg_attr(feature = "cargo-clippy", allow(clippy::too_many_arguments))]

--- a/crates/epoch-snark/src/gadgets/single_update.rs
+++ b/crates/epoch-snark/src/gadgets/single_update.rs
@@ -142,6 +142,7 @@ pub mod test_helpers {
 
     use algebra::ProjectiveCurve;
 
+    #[tracing::instrument(target = "r1cs")]
     pub fn generate_single_update<E: PairingEngine>(
         index: u16,
         epoch_entropy: Option<Vec<u8>>,
@@ -164,6 +165,7 @@ pub mod test_helpers {
         }
     }
 
+    #[tracing::instrument(target = "r1cs")]
     pub fn generate_dummy_update<E: PairingEngine>(num_validators: u32) -> SingleUpdate<E> {
         let bitmap = (0..num_validators).map(|_| true).collect::<Vec<_>>();
         let public_keys = (0..num_validators)


### PR DESCRIPTION
### Description

Each test now uses a wrapper to initializes constraint tracing. Tracing annotations have also been added to some relevant functions which generate constraints.

### Tested

Tests modified to fail printed unsatisfied constraints

### Related issues

https://github.com/celo-org/celo-bls-snark-rs/issues/184

