### PR TITLE
Double hash to curve

### DIFF
--- a/crates/bls-crypto/src/bls/public.rs
+++ b/crates/bls-crypto/src/bls/public.rs
@@ -1,4 +1,4 @@
-use crate::{BLSError, BlsResult, HashToCurve, PrivateKey, Signature, POP_DOMAIN, SIG_DOMAIN};
+use crate::{BLSError, BlsResult, CrhAndXofHashToCurve, PrivateKey, Signature, POP_DOMAIN, SIG_DOMAIN};
 
 use algebra::{
     bls12_377::{Bls12_377, Fq12, G1Projective, G2Affine, G2Projective},
@@ -48,7 +48,7 @@ impl PublicKey {
     /// `hash_to_g1` hasher.
     ///
     /// Uses the `SIG_DOMAIN` under the hood.
-    pub fn verify<H: HashToCurve<Output = G1Projective>>(
+    pub fn verify<H: CrhAndXofHashToCurve<Output = G1Projective>>(
         &self,
         message: &[u8],
         extra_data: &[u8],
@@ -62,7 +62,7 @@ impl PublicKey {
     /// `hash_to_g1` hasher.
     ///
     /// Uses the `POP_DOMAIN` under the hood.
-    pub fn verify_pop<H: HashToCurve<Output = G1Projective>>(
+    pub fn verify_pop<H: CrhAndXofHashToCurve<Output = G1Projective>>(
         &self,
         message: &[u8],
         signature: &Signature,
@@ -71,7 +71,7 @@ impl PublicKey {
         self.verify_sig(POP_DOMAIN, &message, &[], signature, hash_to_g1)
     }
 
-    fn verify_sig<H: HashToCurve<Output = G1Projective>>(
+    fn verify_sig<H: CrhAndXofHashToCurve<Output = G1Projective>>(
         &self,
         domain: &[u8],
         message: &[u8],

--- a/crates/bls-crypto/src/bls/secret.rs
+++ b/crates/bls-crypto/src/bls/secret.rs
@@ -1,4 +1,4 @@
-use crate::{BLSError, HashToCurve, PublicKey, Signature, POP_DOMAIN, SIG_DOMAIN};
+use crate::{BLSError, CrhAndXofHashToCurve, PublicKey, Signature, POP_DOMAIN, SIG_DOMAIN};
 
 use algebra::{
     bls12_377::{Fr, G1Projective},
@@ -31,7 +31,7 @@ impl PrivateKey {
 
     /// Hashes the message/extra_data tuple with the provided `hash_to_g1` function
     /// and then signs it in the SIG_DOMAIN
-    pub fn sign<H: HashToCurve<Output = G1Projective>>(
+    pub fn sign<H: CrhAndXofHashToCurve<Output = G1Projective>>(
         &self,
         message: &[u8],
         extra_data: &[u8],
@@ -42,7 +42,7 @@ impl PrivateKey {
 
     /// Hashes the message with the provided `hash_to_g1` function
     /// and then signs it in the POP_DOMAIN
-    pub fn sign_pop<H: HashToCurve<Output = G1Projective>>(
+    pub fn sign_pop<H: CrhAndXofHashToCurve<Output = G1Projective>>(
         &self,
         message: &[u8],
         hash_to_g1: &H,
@@ -51,7 +51,7 @@ impl PrivateKey {
     }
 
     /// Hashes to G1 and signs the hash
-    fn sign_message<H: HashToCurve<Output = G1Projective>>(
+    fn sign_message<H: CrhAndXofHashToCurve<Output = G1Projective>>(
         &self,
         domain: &[u8],
         message: &[u8],

--- a/crates/bls-crypto/src/bls/signature.rs
+++ b/crates/bls-crypto/src/bls/signature.rs
@@ -1,5 +1,5 @@
 use super::PublicKey;
-use crate::{BLSError, HashToCurve};
+use crate::{BLSError, CrhAndXofHashToCurve};
 
 use algebra::{
     bls12_377::{Bls12_377, Fq12, G1Affine, G1Projective, G2Affine},
@@ -77,7 +77,7 @@ impl Signature {
     ///
     /// The verification equation can be found in pg.11 from
     /// https://eprint.iacr.org/2018/483.pdf: "Batch verification"
-    pub fn batch_verify<H: HashToCurve<Output = G1Projective>, P: Borrow<PublicKey>>(
+    pub fn batch_verify<H: CrhAndXofHashToCurve<Output = G1Projective>, P: Borrow<PublicKey>>(
         &self,
         pubkeys: &[P],
         domain: &[u8],
@@ -162,7 +162,7 @@ mod tests {
         test_aggregated_sig_inner(&*COMPOSITE_HASH_TO_G1_CIP22);
     }
 
-    fn test_aggregated_sig_inner<H: HashToCurve<Output = G1Projective>>(try_and_increment: &H) {
+    fn test_aggregated_sig_inner<H: CrhAndXofHashToCurve<Output = G1Projective>>(try_and_increment: &H) {
         let message = b"hello";
         let rng = &mut thread_rng();
 
@@ -227,7 +227,7 @@ mod tests {
     }
 
     #[allow(unused)] // needed when we don't compile with ffi features
-    fn test_batch_verify_with_hasher<H: HashToCurve<Output = G1Projective>>(
+    fn test_batch_verify_with_hasher<H: CrhAndXofHashToCurve<Output = G1Projective>>(
         try_and_increment: &H,
         is_composite: bool,
         is_cip22: bool,
@@ -349,7 +349,7 @@ mod tests {
         test_signature_serialization_inner(try_and_increment_composite_cip22);
     }
 
-    fn test_signature_serialization_inner<H: HashToCurve<Output = G1Projective>>(
+    fn test_signature_serialization_inner<H: CrhAndXofHashToCurve<Output = G1Projective>>(
         try_and_increment: &H,
     ) {
         let rng = &mut thread_rng();

--- a/crates/bls-crypto/src/hash_to_curve/mod.rs
+++ b/crates/bls-crypto/src/hash_to_curve/mod.rs
@@ -105,6 +105,7 @@ pub fn hash_length(n: usize) -> usize {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::hash_to_curve::CrhAndXofHashToCurve;
     use crate::hash_to_curve::try_and_increment::TryAndIncrement;
     use crate::hashers::{
         composite::{CompositeHasher, CRH},
@@ -154,7 +155,7 @@ mod test {
         for length in &[10, 25, 50, 100, 200, 300] {
             let mut input = vec![0; *length];
             rng.fill_bytes(&mut input);
-            let _ = hasher.hash(&b"domain"[..], &input, &b"extra"[..]).unwrap();
+            let _ = CrhAndXofHashToCurve::hash(&hasher, &b"domain"[..], &input, &b"extra"[..]).unwrap();
         }
     }
 

--- a/crates/bls-crypto/src/hash_to_curve/mod.rs
+++ b/crates/bls-crypto/src/hash_to_curve/mod.rs
@@ -156,6 +156,7 @@ mod test {
             let mut input = vec![0; *length];
             rng.fill_bytes(&mut input);
             let _ = CrhAndXofHashToCurve::hash(&hasher, &b"domain"[..], &input, &b"extra"[..]).unwrap();
+            let _ = HashToCurve::hash(&hasher, &b"domain"[..], &input).unwrap();
         }
     }
 

--- a/crates/bls-crypto/src/hash_to_curve/try_and_increment.rs
+++ b/crates/bls-crypto/src/hash_to_curve/try_and_increment.rs
@@ -3,7 +3,7 @@ use byteorder::WriteBytesExt;
 use log::trace;
 use std::marker::PhantomData;
 
-use super::HashToCurve;
+use super::CrhAndXofHashToCurve;
 use crate::hashers::{
     composite::{CompositeHasher, COMPOSITE_HASHER, CRH},
     DirectHasher, Hasher,
@@ -56,7 +56,7 @@ where
     }
 }
 
-impl<'a, H, P> HashToCurve for TryAndIncrement<'a, H, P>
+impl<'a, H, P> CrhAndXofHashToCurve for TryAndIncrement<'a, H, P>
 where
     H: Hasher<Error = BLSError>,
     P: SWModelParameters,

--- a/crates/bls-crypto/src/hash_to_curve/try_and_increment_cip22.rs
+++ b/crates/bls-crypto/src/hash_to_curve/try_and_increment_cip22.rs
@@ -3,7 +3,7 @@ use byteorder::WriteBytesExt;
 use log::trace;
 use std::marker::PhantomData;
 
-use super::HashToCurve;
+use super::CrhAndXofHashToCurve;
 use crate::hashers::{
     composite::{CompositeHasher, COMPOSITE_HASHER, CRH},
     Hasher,
@@ -50,7 +50,7 @@ where
     }
 }
 
-impl<'a, H, P> HashToCurve for TryAndIncrementCIP22<'a, H, P>
+impl<'a, H, P> CrhAndXofHashToCurve for TryAndIncrementCIP22<'a, H, P>
 where
     H: Hasher<Error = BLSError>,
     P: SWModelParameters,

--- a/crates/bls-crypto/src/lib.rs
+++ b/crates/bls-crypto/src/lib.rs
@@ -57,6 +57,7 @@ pub use bls::{PrivateKey, PublicKey, PublicKeyCache, Signature};
 /// Traits and implementations for hashing arbitrary data to an elliptic curve's group element
 pub mod hash_to_curve;
 pub use hash_to_curve::HashToCurve;
+pub use hash_to_curve::CrhAndXofHashToCurve;
 
 /// Hash function implementations using a CRH followed by a XOF.
 pub mod hashers;

--- a/crates/bls-snark-sys/src/signatures.rs
+++ b/crates/bls-snark-sys/src/signatures.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use algebra::{ProjectiveCurve, ToBytes};
 use bls_crypto::hash_to_curve::try_and_increment_cip22::COMPOSITE_HASH_TO_G1_CIP22;
-use bls_crypto::{BLSError, HashToCurve, POP_DOMAIN, SIG_DOMAIN};
+use bls_crypto::{BLSError, CrhAndXofHashToCurve, POP_DOMAIN, SIG_DOMAIN};
 use std::{os::raw::c_int, slice};
 
 /// # Safety

--- a/crates/epoch-snark/src/epoch_block.rs
+++ b/crates/epoch-snark/src/epoch_block.rs
@@ -6,7 +6,7 @@ use algebra::{
 };
 use blake2s_simd::Params;
 use bls_crypto::{
-    hash_to_curve::{try_and_increment_cip22::COMPOSITE_HASH_TO_G1_CIP22, HashToCurve},
+    hash_to_curve::{try_and_increment_cip22::COMPOSITE_HASH_TO_G1_CIP22, CrhAndXofHashToCurve},
     PublicKey, Signature, OUT_DOMAIN, SIG_DOMAIN,
 };
 use bls_gadgets::utils::{bits_be_to_bytes_le, bytes_le_to_bits_le};


### PR DESCRIPTION
### Description

This changes the `HashToCurve` trait used to `CrhAndXofHashToCurve`, and introduces a new `HashToCurve` trait without the `extra_data` API.

It remains to decide how to handle the `hash_with_attempt` methods on the try and increment functions. (Should they have extra data or no?) The only thing that remains for this PR is to update the doc tests depending on this decision.

### Tested

The existing tests were updated to use the new `CrhAndXofHashToCurve` API.

### Other changes

Added some more docs to the traits as well

### Related issues

Closes #201 

