### PR TITLE
fix: disallow the padding value as a public key in an activated location

### DIFF
--- a/crates/epoch-snark/src/epoch_block.rs
+++ b/crates/epoch-snark/src/epoch_block.rs
@@ -94,6 +94,10 @@ impl EpochBlock {
         Ok(hash_to_bits(&self.encode_first_epoch_to_bytes_cip22()?))
     }
 
+    pub fn padding_pk() -> G2Projective {
+        G2Projective::prime_subgroup_generator()
+    }
+
     /// Encodes the block appended with the aggregate signature to bytes and then hashes it with Blake2
     pub fn blake2_last_epoch_with_aggregated_pk_cip22(&self) -> Result<Vec<bool>, EncodingError> {
         Ok(hash_to_bits(
@@ -130,9 +134,9 @@ impl EpochBlock {
         }
         if self.maximum_validators > self.new_public_keys.len() {
             let difference = self.maximum_validators - self.new_public_keys.len();
-            let generator = PublicKey::from(G2Projective::prime_subgroup_generator());
+            let padding_pk = PublicKey::from(Self::padding_pk());
             for _ in 0..difference {
-                epoch_bits.extend_from_slice(encode_public_key(&generator)?.as_slice());
+                epoch_bits.extend_from_slice(encode_public_key(&padding_pk)?.as_slice());
             }
         }
         Ok(epoch_bits)
@@ -161,9 +165,9 @@ impl EpochBlock {
         }
         if self.maximum_validators > self.new_public_keys.len() {
             let difference = self.maximum_validators - self.new_public_keys.len();
-            let generator = PublicKey::from(G2Projective::prime_subgroup_generator());
+            let padding_pk = PublicKey::from(Self::padding_pk());
             for _ in 0..difference {
-                epoch_bits.extend_from_slice(encode_public_key(&generator)?.as_slice());
+                epoch_bits.extend_from_slice(encode_public_key(&padding_pk)?.as_slice());
             }
         }
         Ok((epoch_bits, extra_data_bits))

--- a/crates/epoch-snark/src/gadgets/epoch_data.rs
+++ b/crates/epoch-snark/src/gadgets/epoch_data.rs
@@ -179,7 +179,7 @@ impl EpochData<Bls12_377> {
 
         let extra_data_bits: Vec<Bool> = [
             index_bits.clone(),
-            round_bits.clone(),
+            round_bits,
             maximum_non_signers_bits.clone(),
         ]
         .concat();

--- a/crates/epoch-snark/src/gadgets/single_update.rs
+++ b/crates/epoch-snark/src/gadgets/single_update.rs
@@ -14,7 +14,9 @@ use r1cs_std::{
 };
 
 use super::{constrain_bool, EpochData};
+use crate::EpochBlock;
 use bls_gadgets::{BlsVerifyGadget, FpUtils};
+use r1cs_std::groups::CurveVar;
 use tracing::{span, Level};
 
 // Instantiate the BLS Verification gadget
@@ -120,6 +122,7 @@ impl SingleUpdate<Bls12_377> {
             &signed_bitmap,
             &epoch_data.message_hash,
             &previous_max_non_signers,
+            &G2Var::constant(EpochBlock::padding_pk()),
         )?;
 
         Ok(ConstrainedEpoch {


### PR DESCRIPTION
### Description

This PR disallows using the padding public key as a public key in a location where a bit is active.

This prevents an attack where a malicious prover could use the padding public keys, which are defined currently to be the generator, as part of the used public keys in a block. This is bad, since the secret key against these is known - it's just `one`.

An alternative solution would have been to use an element with an unknown discrete log against the generator as the padding value. This is worse, in my opinion, since we'd have to convince that the discrete log is unknown. It's somewhat OK if we use a hash to derive it, but still requires to inspire confidence in it.

### Tested

Added a test that shows the proofs fail when the padding value is used.
