### PR TITLE
feat: adds API methods relevant for slashing

### DIFF
--- a/crates/bls-crypto/src/hash_to_curve/try_and_increment_cip22.rs
+++ b/crates/bls-crypto/src/hash_to_curve/try_and_increment_cip22.rs
@@ -73,24 +73,12 @@ where
     H: Hasher<Error = BLSError>,
     P: SWModelParameters,
 {
-   /// Hash with attempt takes the input, appends a counter
-   pub fn hash_with_attempt_cip22(
+    /// Hash with attempt takes the input, appends a counter
+    pub fn hash_with_attempt_cip22(
         &self,
         domain: &[u8],
         message: &[u8],
         extra_data: &[u8],
-    ) -> Result<(GroupProjective<P>, usize), BLSError> {
-        let mut counter = 0;
-        self.hash_with_attempt_cip22_counter(domain, message, extra_data, &mut counter)
-    }
-
- /// Hash with attempt takes the input, appends a counter
-    pub fn hash_with_attempt_cip22_counter(
-        &self,
-        domain: &[u8],
-        message: &[u8],
-        extra_data: &[u8],
-        counter_out: &mut u8,
     ) -> Result<(GroupProjective<P>, usize), BLSError> {
         let num_bytes = GroupAffine::<P>::SERIALIZED_SIZE;
         let hash_loop_time = start_timer!(|| "try_and_increment::hash_loop");
@@ -98,7 +86,6 @@ where
         let inner_hash = self.hasher.crh(domain, &message, hash_bytes)?;
         let mut counter = [0; 1];
         for c in 0..NUM_TRIES {
-            *counter_out = c;
             (&mut counter[..]).write_u8(c as u8)?;
 
             // concatenate the message with the counter
@@ -140,16 +127,4 @@ where
         }
         Err(BLSError::HashToCurveError)
     }
-
-    pub fn hash_with_counter(
-        &self,
-        domain: &[u8],
-        message: &[u8],
-        extra_data: &[u8],
-        counter: &mut u8,
-    ) -> Result<GroupProjective<P>, BLSError> {
-        self.hash_with_attempt_cip22_counter(domain, message, extra_data, counter)
-            .map(|res| res.0)
-    }
-
 }

--- a/crates/bls-snark-sys/src/signatures.rs
+++ b/crates/bls-snark-sys/src/signatures.rs
@@ -142,12 +142,13 @@ pub extern "C" fn hash_composite(
 pub extern "C" fn hash_crh(
     in_message: *const u8,
     in_message_len: c_int,
+    hash_bytes: c_int,
     out_hash: *mut *mut u8,
     out_len: *mut c_int,
 ) -> bool {
     convert_result_to_bool::<_, BLSError, _>(|| {
         let message = unsafe { slice::from_raw_parts(in_message, in_message_len as usize) };
-        let hash = COMPOSITE_HASHER.crh(SIG_DOMAIN, message, 256)?;
+        let hash = COMPOSITE_HASHER.crh(SIG_DOMAIN, message, hash_bytes as usize)?;
         let mut obj_bytes = vec![];
         hash.write(&mut obj_bytes)?;
         obj_bytes.shrink_to_fit();

--- a/crates/bls-snark-sys/src/signatures.rs
+++ b/crates/bls-snark-sys/src/signatures.rs
@@ -168,7 +168,7 @@ pub extern "C" fn hash_composite_cip22(
     in_extra_data_len: c_int,
     out_hash: *mut *mut u8,
     out_len: *mut c_int,
-    attempt_counter: *mut c_int,
+    attempt_counter: *mut u8,
 ) -> bool {
     convert_result_to_bool::<_, BLSError, _>(|| {
         let message = unsafe { slice::from_raw_parts(in_message, in_message_len as usize) };
@@ -182,7 +182,7 @@ pub extern "C" fn hash_composite_cip22(
         unsafe {
             *out_hash = obj_bytes.as_mut_ptr();
             *out_len = obj_bytes.len() as c_int;
-            *attempt_counter = counter as c_int;
+            *attempt_counter = counter;
         }
         std::mem::forget(obj_bytes);
         Ok(())

--- a/crates/bls-snark-sys/src/signatures.rs
+++ b/crates/bls-snark-sys/src/signatures.rs
@@ -6,9 +6,9 @@ use crate::{
 };
 use algebra::{ProjectiveCurve, ToBytes};
 use bls_crypto::hash_to_curve::try_and_increment_cip22::COMPOSITE_HASH_TO_G1_CIP22;
-use bls_crypto::{BLSError, HashToCurve, POP_DOMAIN, SIG_DOMAIN};
 use bls_crypto::hashers::COMPOSITE_HASHER;
 use bls_crypto::Hasher;
+use bls_crypto::{BLSError, HashToCurve, POP_DOMAIN, SIG_DOMAIN};
 use std::{os::raw::c_int, slice};
 
 /// # Safety
@@ -174,7 +174,8 @@ pub extern "C" fn hash_composite_cip22(
         let message = unsafe { slice::from_raw_parts(in_message, in_message_len as usize) };
         let extra_data =
             unsafe { slice::from_raw_parts(in_extra_data, in_extra_data_len as usize) };
-        let (hash, counter) = COMPOSITE_HASH_TO_G1_CIP22.hash_with_attempt_cip22(SIG_DOMAIN, message, extra_data)?;
+        let (hash, counter) =
+            COMPOSITE_HASH_TO_G1_CIP22.hash_with_attempt_cip22(SIG_DOMAIN, message, extra_data)?;
         let mut obj_bytes = vec![];
         hash.write(&mut obj_bytes)?;
         obj_bytes.shrink_to_fit();

--- a/crates/bls-snark-sys/src/signatures.rs
+++ b/crates/bls-snark-sys/src/signatures.rs
@@ -174,15 +174,14 @@ pub extern "C" fn hash_composite_cip22(
         let message = unsafe { slice::from_raw_parts(in_message, in_message_len as usize) };
         let extra_data =
             unsafe { slice::from_raw_parts(in_extra_data, in_extra_data_len as usize) };
-        let mut counter = 0;
-        let hash = COMPOSITE_HASH_TO_G1_CIP22.hash_with_counter(SIG_DOMAIN, message, extra_data, &mut counter)?;
+        let (hash, counter) = COMPOSITE_HASH_TO_G1_CIP22.hash_with_attempt_cip22(SIG_DOMAIN, message, extra_data)?;
         let mut obj_bytes = vec![];
         hash.write(&mut obj_bytes)?;
         obj_bytes.shrink_to_fit();
         unsafe {
             *out_hash = obj_bytes.as_mut_ptr();
             *out_len = obj_bytes.len() as c_int;
-            *attempt_counter = counter;
+            *attempt_counter = counter as u8;
         }
         std::mem::forget(obj_bytes);
         Ok(())

--- a/crates/bls-snark-sys/src/signatures.rs
+++ b/crates/bls-snark-sys/src/signatures.rs
@@ -7,6 +7,8 @@ use crate::{
 use algebra::{ProjectiveCurve, ToBytes};
 use bls_crypto::hash_to_curve::try_and_increment_cip22::COMPOSITE_HASH_TO_G1_CIP22;
 use bls_crypto::{BLSError, HashToCurve, POP_DOMAIN, SIG_DOMAIN};
+use bls_crypto::hashers::COMPOSITE_HASHER;
+use bls_crypto::Hasher;
 use std::{os::raw::c_int, slice};
 
 /// # Safety
@@ -137,6 +139,28 @@ pub extern "C" fn hash_composite(
 }
 
 #[no_mangle]
+pub extern "C" fn hash_crh(
+    in_message: *const u8,
+    in_message_len: c_int,
+    out_hash: *mut *mut u8,
+    out_len: *mut c_int,
+) -> bool {
+    convert_result_to_bool::<_, BLSError, _>(|| {
+        let message = unsafe { slice::from_raw_parts(in_message, in_message_len as usize) };
+        let hash = COMPOSITE_HASHER.crh(SIG_DOMAIN, message, 256)?;
+        let mut obj_bytes = vec![];
+        hash.write(&mut obj_bytes)?;
+        obj_bytes.shrink_to_fit();
+        unsafe {
+            *out_hash = obj_bytes.as_mut_ptr();
+            *out_len = obj_bytes.len() as c_int;
+        }
+        std::mem::forget(obj_bytes);
+        Ok(())
+    })
+}
+
+#[no_mangle]
 pub extern "C" fn hash_composite_cip22(
     in_message: *const u8,
     in_message_len: c_int,
@@ -144,18 +168,21 @@ pub extern "C" fn hash_composite_cip22(
     in_extra_data_len: c_int,
     out_hash: *mut *mut u8,
     out_len: *mut c_int,
+    attempt_counter: *mut c_int,
 ) -> bool {
     convert_result_to_bool::<_, BLSError, _>(|| {
         let message = unsafe { slice::from_raw_parts(in_message, in_message_len as usize) };
         let extra_data =
             unsafe { slice::from_raw_parts(in_extra_data, in_extra_data_len as usize) };
-        let hash = COMPOSITE_HASH_TO_G1_CIP22.hash(SIG_DOMAIN, message, extra_data)?;
+        let mut counter = 0;
+        let hash = COMPOSITE_HASH_TO_G1_CIP22.hash_with_counter(SIG_DOMAIN, message, extra_data, &mut counter)?;
         let mut obj_bytes = vec![];
         hash.write(&mut obj_bytes)?;
         obj_bytes.shrink_to_fit();
         unsafe {
             *out_hash = obj_bytes.as_mut_ptr();
             *out_len = obj_bytes.len() as c_int;
+            *attempt_counter = counter as c_int;
         }
         std::mem::forget(obj_bytes);
         Ok(())


### PR DESCRIPTION
### Description

Two additions to the API
 * CRH hash (Bowe-Hopwood Pedersen hash)
 * Added counter to return value of composite hash (cip 22 version)

### Tested

### Other changes

### Related issues


