### PR TITLE
use integer based ceil() method, instead of float arithmetic

### DIFF
--- a/crates/bls-crypto/src/hash_to_curve/mod.rs
+++ b/crates/bls-crypto/src/hash_to_curve/mod.rs
@@ -66,8 +66,7 @@ pub trait HashToCurve {
 ///      2. given 96 = 768 bits, it will return 96 bytes (no rounding needed since 768 is already a
 ///         multiple of 256)
 pub fn hash_length(n: usize) -> usize {
-    let bits = (n * 8) as f64 / 256.0;
-    let rounded_bits = bits.ceil() * 256.0;
+    let rounded_bits = (((n * 8) -1 + 256) / 256) * 256;
     rounded_bits as usize / 8
 }
 


### PR DESCRIPTION
### Description

I am working on Celo Light Client (rust) that utilizes this library to validate the BLS signature. The LC compiles to WASM format and then it's executed on the Cosmos Chain.

The issue I have is that WASM/CosmWASM doesn't work with floating-point arithmetic, therefore I had to change `hash_length` function to float-free implementation.

The `ceil` can be achieved via ~[trick](https://www.geeksforgeeks.org/find-ceil-ab-without-using-ceil-function/): `ceilVal = (a+b-1) / b`

### Tested

All tests are passing after the PR is applied (run via `cargo test`)

### Other changes

none

### Related issues

none

