### PR TITLE
Pin versions of arkworks libs in patch section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ dependencies = [
 [[package]]
 name = "ark-snark"
 version = "0.1.0"
-source = "git+https://github.com/arkworks-rs/snark#8d9055d5397b510716ad2951ce1f18675aebe7c8"
+source = "git+https://github.com//arkworks-rs/snark?rev=8d9055d#8d9055d5397b510716ad2951ce1f18675aebe7c8"
 dependencies = [
  "ark-ff",
  "ark-relations",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ ark-groth16 = { git = "https://github.com//arkworks-rs/groth16", rev = "d8acb2b"
 
 [patch."https://github.com/arkworks-rs/snark"]
 ark-relations = { git = "https://github.com//arkworks-rs/snark", rev = "8d9055d" }
+ark-snark = { git = "https://github.com//arkworks-rs/snark", rev = "8d9055d"}
 
 [patch."https://github.com/arkworks-rs/r1cs-std"]
 ark-r1cs-std = { git = "https://github.com//arkworks-rs/r1cs-std", rev = "e5ec2e6" }


### PR DESCRIPTION
Pinned the versions of arkworks dependencies so that circuits won't change as the libs get updated.


