### PR TITLE
deps: fake the old bench-utils structure to avoid pulling in ark-std 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-r1cs-std",
- "ark-std 0.1.0",
+ "ark-std 0.1.0 (git+https://github.com/arkworks-rs/utils)",
 ]
 
 [[package]]
@@ -54,7 +54,7 @@ dependencies = [
  "ark-bls12-377",
  "ark-ec",
  "ark-ff",
- "ark-std 0.1.0",
+ "ark-std 0.1.0 (git+https://github.com/arkworks-rs/utils)",
 ]
 
 [[package]]
@@ -68,12 +68,12 @@ dependencies = [
  "ark-r1cs-std",
  "ark-relations",
  "ark-snark",
- "ark-std 0.1.0",
- "bench-utils",
+ "ark-std 0.1.0 (git+https://github.com/arkworks-rs/utils)",
+ "bench-utils 0.1.0 (git+https://github.com/arkworks-rs/utils)",
  "blake2",
  "derivative",
  "digest",
- "rand 0.7.3",
+ "rand",
  "rayon",
  "tracing",
 ]
@@ -85,10 +85,10 @@ source = "git+https://github.com/arkworks-rs/algebra#8d76d181de0079b7e5a92f6e113
 dependencies = [
  "ark-ff",
  "ark-serialize",
- "ark-std 0.1.0",
+ "ark-std 0.1.0 (git+https://github.com/arkworks-rs/utils)",
  "derivative",
  "num-traits",
- "rand 0.7.3",
+ "rand",
  "rayon",
  "zeroize",
 ]
@@ -101,7 +101,7 @@ dependencies = [
  "ark-bls12-377",
  "ark-ec",
  "ark-ff",
- "ark-std 0.1.0",
+ "ark-std 0.1.0 (git+https://github.com/arkworks-rs/utils)",
 ]
 
 [[package]]
@@ -120,7 +120,7 @@ dependencies = [
  "ark-bls12-377",
  "ark-ec",
  "ark-ff",
- "ark-std 0.1.0",
+ "ark-std 0.1.0 (git+https://github.com/arkworks-rs/utils)",
 ]
 
 [[package]]
@@ -131,10 +131,10 @@ dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
  "ark-serialize",
- "ark-std 0.1.0",
+ "ark-std 0.1.0 (git+https://github.com/arkworks-rs/utils)",
  "derivative",
  "num-traits",
- "rand 0.7.3",
+ "rand",
  "rayon",
  "rustc_version 0.3.3",
  "zeroize",
@@ -172,10 +172,10 @@ dependencies = [
  "ark-r1cs-std",
  "ark-relations",
  "ark-serialize",
- "ark-std 0.1.0",
- "bench-utils",
+ "ark-std 0.1.0 (git+https://github.com/arkworks-rs/utils)",
+ "bench-utils 0.1.0 (git+https://github.com/arkworks-rs/utils)",
  "derivative",
- "rand 0.7.3",
+ "rand",
  "rayon",
  "tracing",
 ]
@@ -189,12 +189,12 @@ dependencies = [
  "ark-ff",
  "ark-r1cs-std",
  "ark-relations",
- "ark-std 0.1.0",
+ "ark-std 0.1.0 (git+https://github.com/arkworks-rs/utils)",
  "derivative",
  "num-bigint",
  "num-integer",
  "num-traits",
- "rand 0.7.3",
+ "rand",
  "tracing",
 ]
 
@@ -205,10 +205,10 @@ source = "git+https://github.com/arkworks-rs/algebra#8d76d181de0079b7e5a92f6e113
 dependencies = [
  "ark-ff",
  "ark-serialize",
- "ark-std 0.1.0",
+ "ark-std 0.1.0 (git+https://github.com/arkworks-rs/utils)",
  "derivative",
  "hashbrown",
- "rand 0.7.3",
+ "rand",
  "rayon",
 ]
 
@@ -220,7 +220,7 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-relations",
- "ark-std 0.1.0",
+ "ark-std 0.1.0 (git+https://github.com/arkworks-rs/utils)",
  "derivative",
  "tracing",
 ]
@@ -231,7 +231,7 @@ version = "0.1.0"
 source = "git+https://github.com/arkworks-rs/snark#8d9055d5397b510716ad2951ce1f18675aebe7c8"
 dependencies = [
  "ark-ff",
- "ark-std 0.1.0",
+ "ark-std 0.1.0 (git+https://github.com/arkworks-rs/utils)",
  "tracing",
  "tracing-subscriber",
 ]
@@ -242,7 +242,7 @@ version = "0.1.0"
 source = "git+https://github.com/arkworks-rs/algebra#8d76d181de0079b7e5a92f6e1133e7be635efdd3"
 dependencies = [
  "ark-serialize-derive",
- "ark-std 0.1.0",
+ "ark-std 0.1.0 (git+https://github.com/arkworks-rs/utils)",
 ]
 
 [[package]]
@@ -262,8 +262,16 @@ source = "git+https://github.com/arkworks-rs/snark#8d9055d5397b510716ad2951ce1f1
 dependencies = [
  "ark-ff",
  "ark-relations",
- "ark-std 0.1.0",
- "rand 0.7.3",
+ "ark-std 0.1.0 (git+https://github.com/arkworks-rs/utils)",
+ "rand",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.1.0"
+source = "git+https://github.com/arkworks-rs/std?rev=b37f1c8#b37f1c8f73c94c5648b6dd310d02c3a81c8a37e9"
+dependencies = [
+ "rand",
 ]
 
 [[package]]
@@ -271,18 +279,8 @@ name = "ark-std"
 version = "0.1.0"
 source = "git+https://github.com/arkworks-rs/utils#b37f1c8f73c94c5648b6dd310d02c3a81c8a37e9"
 dependencies = [
- "rand 0.7.3",
+ "rand",
  "rayon",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.3.0"
-source = "git+https://github.com/arkworks-rs/std#d0be44c030b35f369db6f9431903a283c077a1b9"
-dependencies = [
- "colored",
- "num-traits",
- "rand 0.8.4",
 ]
 
 [[package]]
@@ -313,6 +311,11 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "bench-utils"
+version = "0.1.0"
+source = "git+https://github.com/arkworks-rs/std?rev=b37f1c8#b37f1c8f73c94c5648b6dd310d02c3a81c8a37e9"
 
 [[package]]
 name = "bench-utils"
@@ -358,7 +361,8 @@ dependencies = [
  "ark-ed-on-bw6-761",
  "ark-ff",
  "ark-serialize",
- "ark-std 0.3.0",
+ "ark-std 0.1.0 (git+https://github.com/arkworks-rs/std?rev=b37f1c8)",
+ "bench-utils 0.1.0 (git+https://github.com/arkworks-rs/std?rev=b37f1c8)",
  "blake2s_simd",
  "byteorder",
  "clap",
@@ -369,8 +373,8 @@ dependencies = [
  "log",
  "lru",
  "once_cell",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
+ "rand",
+ "rand_chacha",
  "rand_xorshift",
  "thiserror",
 ]
@@ -390,7 +394,7 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "bls-crypto",
- "rand 0.7.3",
+ "rand",
  "rand_xorshift",
  "tracing",
  "tracing-subscriber",
@@ -412,7 +416,7 @@ dependencies = [
  "hex",
  "log",
  "once_cell",
- "rand 0.7.3",
+ "rand",
 ]
 
 [[package]]
@@ -492,17 +496,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "colored"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi",
 ]
 
 [[package]]
@@ -677,13 +670,14 @@ dependencies = [
  "ark-r1cs-std",
  "ark-relations",
  "ark-serialize",
- "ark-std 0.3.0",
+ "ark-std 0.1.0 (git+https://github.com/arkworks-rs/std?rev=b37f1c8)",
+ "bench-utils 0.1.0 (git+https://github.com/arkworks-rs/std?rev=b37f1c8)",
  "blake2s_simd",
  "bls-crypto",
  "bls-gadgets",
  "byteorder",
  "hex",
- "rand 0.7.3",
+ "rand",
  "rand_xorshift",
  "thiserror",
  "tracing",
@@ -707,18 +701,7 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -950,23 +933,11 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.16",
+ "getrandom",
  "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.3",
- "rand_hc 0.3.1",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
 ]
 
 [[package]]
@@ -976,17 +947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -995,16 +956,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
-dependencies = [
- "getrandom 0.2.3",
+ "getrandom",
 ]
 
 [[package]]
@@ -1013,16 +965,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -1031,7 +974,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
 dependencies = [
- "rand_core 0.5.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -1435,12 +1378,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"

--- a/crates/bls-crypto/Cargo.toml
+++ b/crates/bls-crypto/Cargo.toml
@@ -9,7 +9,8 @@ ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves" }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", features = [ "derive" ] }
 ark-ff = { git = "https://github.com/arkworks-rs/algebra", features = [ "std", "parallel"] }
 ark-ec = { git = "https://github.com/arkworks-rs/algebra", features = [ "std", "parallel"] }
-ark-std = { git = "https://github.com/arkworks-rs/std" }
+ark-std = { git = "https://github.com/arkworks-rs/std", rev = "b37f1c8" }
+bench-utils = { git = "https://github.com/arkworks-rs/std", rev = "b37f1c8" }
 ark-ed-on-bw6-761 = { git = "https://github.com/arkworks-rs/curves" }
 ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives", branch = "main", features = ["parallel"] }
 

--- a/crates/bls-crypto/src/hash_to_curve/mod.rs
+++ b/crates/bls-crypto/src/hash_to_curve/mod.rs
@@ -281,7 +281,7 @@ mod compat_tests {
     };
     use ark_ff::{Field, FpParameters, FromBytes, PrimeField, SquareRootField, Zero};
     use ark_serialize::CanonicalSerialize;
-    use ark_std::{end_timer, start_timer};
+    use bench_utils::{end_timer, start_timer};
     use byteorder::WriteBytesExt;
     use log::trace;
     use rand::SeedableRng;

--- a/crates/bls-crypto/src/hash_to_curve/try_and_increment.rs
+++ b/crates/bls-crypto/src/hash_to_curve/try_and_increment.rs
@@ -1,4 +1,4 @@
-use ark_std::{end_timer, start_timer};
+use bench_utils::{end_timer, start_timer};
 use byteorder::WriteBytesExt;
 use log::trace;
 use std::marker::PhantomData;

--- a/crates/bls-crypto/src/hash_to_curve/try_and_increment_cip22.rs
+++ b/crates/bls-crypto/src/hash_to_curve/try_and_increment_cip22.rs
@@ -1,4 +1,4 @@
-use ark_std::{end_timer, start_timer};
+use bench_utils::{end_timer, start_timer};
 use byteorder::WriteBytesExt;
 use log::trace;
 use std::marker::PhantomData;

--- a/crates/epoch-snark/Cargo.toml
+++ b/crates/epoch-snark/Cargo.toml
@@ -19,7 +19,8 @@ ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std", default-featur
 ark-relations = { git = "https://github.com/arkworks-rs/snark", features = [ "std" ] }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", features = [ "derive" ] }
 ark-groth16 = { git = "https://github.com/arkworks-rs/groth16", features = [ "std", "parallel", "r1cs" ] }
-ark-std = { git = "https://github.com/arkworks-rs/std" }
+ark-std = { git = "https://github.com/arkworks-rs/std", rev = "b37f1c8" }
+bench-utils = { git = "https://github.com/arkworks-rs/std", rev = "b37f1c8" }
 
 rand = "0.7"
 byteorder = "1.3.2"
@@ -36,7 +37,8 @@ hex = "0.4.2"
 
 [features]
 default = ["compat"]
-print-trace = ["ark-std/print-trace"]
+# arkworks 0.1.0 does not have this feature
+#print-trace = ["ark-std/print-trace"]
 compat = ["bls-crypto/compat", "bls-gadgets/compat"]
 
 [lib]

--- a/crates/epoch-snark/examples/proof.rs
+++ b/crates/epoch-snark/examples/proof.rs
@@ -10,7 +10,7 @@ use tracing_subscriber::{
     fmt::{time::ChronoUtc, Subscriber},
 };
 
-use ark_std::{end_timer, start_timer};
+use bench_utils::{end_timer, start_timer};
 
 fn main() {
     Subscriber::builder()


### PR DESCRIPTION
When I followed the upstream refactoring earlier, it induced a dependency on the newer ark-std, causing our downstream code (like the Plumo prover) to transitively depend on it as well.

### Tested

Builds, tests pass, and there is no ark 0.3.x in the dependency tree anymore.

### Related issues

This is part of the fix for the plumo prover build https://github.com/gtank/plumo-prover/commit/a8abea11bea6e43824ed6c74e89575b33baab9f5

