### PR TITLE
Use patching to pin arkworks-rs dependencies (incl. transitively)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
 [[package]]
 name = "ark-bls12-377"
 version = "0.1.0"
-source = "git+https://github.com/arkworks-rs/curves#6ed2450b5505de5d451f629bb6642e3977bf66e2"
+source = "git+https://github.com/arkworks-rs/curves//?rev=6ed2450b5505de5d451f629bb6642e3977bf66e2#6ed2450b5505de5d451f629bb6642e3977bf66e2"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -51,7 +51,7 @@ dependencies = [
 [[package]]
 name = "ark-bw6-761"
 version = "0.1.0"
-source = "git+https://github.com/arkworks-rs/curves#6ed2450b5505de5d451f629bb6642e3977bf66e2"
+source = "git+https://github.com/arkworks-rs/curves//?rev=6ed2450b5505de5d451f629bb6642e3977bf66e2#6ed2450b5505de5d451f629bb6642e3977bf66e2"
 dependencies = [
  "ark-bls12-377",
  "ark-ec",
@@ -62,7 +62,7 @@ dependencies = [
 [[package]]
 name = "ark-crypto-primitives"
 version = "0.1.0"
-source = "git+https://github.com/arkworks-rs/crypto-primitives?branch=main#fde39ab764f00e28b2f292af3706a2654ea55edb"
+source = "git+https://github.com/arkworks-rs/crypto-primitives//?rev=fde39ab764f00e28b2f292af3706a2654ea55edb#fde39ab764f00e28b2f292af3706a2654ea55edb"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -83,7 +83,7 @@ dependencies = [
 [[package]]
 name = "ark-ec"
 version = "0.1.0"
-source = "git+https://github.com/arkworks-rs/algebra#8d76d181de0079b7e5a92f6e1133e7be635efdd3"
+source = "git+https://github.com/arkworks-rs/algebra//?rev=8d76d181de0079b7e5a92f6e1133e7be635efdd3#8d76d181de0079b7e5a92f6e1133e7be635efdd3"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -98,7 +98,7 @@ dependencies = [
 [[package]]
 name = "ark-ed-on-bls12-377"
 version = "0.1.0"
-source = "git+https://github.com/arkworks-rs/curves#6ed2450b5505de5d451f629bb6642e3977bf66e2"
+source = "git+https://github.com/arkworks-rs/curves//?rev=6ed2450b5505de5d451f629bb6642e3977bf66e2#6ed2450b5505de5d451f629bb6642e3977bf66e2"
 dependencies = [
  "ark-bls12-377",
  "ark-ec",
@@ -109,7 +109,7 @@ dependencies = [
 [[package]]
 name = "ark-ed-on-bw6-761"
 version = "0.1.0"
-source = "git+https://github.com/arkworks-rs/curves#6ed2450b5505de5d451f629bb6642e3977bf66e2"
+source = "git+https://github.com/arkworks-rs/curves//?rev=6ed2450b5505de5d451f629bb6642e3977bf66e2#6ed2450b5505de5d451f629bb6642e3977bf66e2"
 dependencies = [
  "ark-ed-on-cp6-782",
 ]
@@ -117,7 +117,7 @@ dependencies = [
 [[package]]
 name = "ark-ed-on-cp6-782"
 version = "0.1.0"
-source = "git+https://github.com/arkworks-rs/curves#6ed2450b5505de5d451f629bb6642e3977bf66e2"
+source = "git+https://github.com/arkworks-rs/curves//?rev=6ed2450b5505de5d451f629bb6642e3977bf66e2#6ed2450b5505de5d451f629bb6642e3977bf66e2"
 dependencies = [
  "ark-bls12-377",
  "ark-ec",
@@ -128,7 +128,7 @@ dependencies = [
 [[package]]
 name = "ark-ff"
 version = "0.1.0"
-source = "git+https://github.com/arkworks-rs/algebra#8d76d181de0079b7e5a92f6e1133e7be635efdd3"
+source = "git+https://github.com/arkworks-rs/algebra//?rev=8d76d181de0079b7e5a92f6e1133e7be635efdd3#8d76d181de0079b7e5a92f6e1133e7be635efdd3"
 dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
@@ -145,7 +145,7 @@ dependencies = [
 [[package]]
 name = "ark-ff-asm"
 version = "0.1.0"
-source = "git+https://github.com/arkworks-rs/algebra#8d76d181de0079b7e5a92f6e1133e7be635efdd3"
+source = "git+https://github.com/arkworks-rs/algebra//?rev=8d76d181de0079b7e5a92f6e1133e7be635efdd3#8d76d181de0079b7e5a92f6e1133e7be635efdd3"
 dependencies = [
  "quote",
  "syn",
@@ -154,7 +154,7 @@ dependencies = [
 [[package]]
 name = "ark-ff-macros"
 version = "0.1.0"
-source = "git+https://github.com/arkworks-rs/algebra#8d76d181de0079b7e5a92f6e1133e7be635efdd3"
+source = "git+https://github.com/arkworks-rs/algebra//?rev=8d76d181de0079b7e5a92f6e1133e7be635efdd3#8d76d181de0079b7e5a92f6e1133e7be635efdd3"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -165,7 +165,7 @@ dependencies = [
 [[package]]
 name = "ark-groth16"
 version = "0.1.0"
-source = "git+https://github.com/arkworks-rs/groth16#d8acb2b2108023b2ad09974040b347b03bfe70b1"
+source = "git+https://github.com/arkworks-rs/groth16//?rev=d8acb2b2108023b2ad09974040b347b03bfe70b1#d8acb2b2108023b2ad09974040b347b03bfe70b1"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -203,7 +203,7 @@ dependencies = [
 [[package]]
 name = "ark-poly"
 version = "0.1.0"
-source = "git+https://github.com/arkworks-rs/algebra#8d76d181de0079b7e5a92f6e1133e7be635efdd3"
+source = "git+https://github.com/arkworks-rs/algebra//?rev=8d76d181de0079b7e5a92f6e1133e7be635efdd3#8d76d181de0079b7e5a92f6e1133e7be635efdd3"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -217,7 +217,7 @@ dependencies = [
 [[package]]
 name = "ark-r1cs-std"
 version = "0.1.0"
-source = "git+https://github.com/arkworks-rs/r1cs-std#e5ec2e66d3aead34f7e3fa15909f22e1600bd11d"
+source = "git+https://github.com/arkworks-rs/r1cs-std//?rev=e5ec2e66d3aead34f7e3fa15909f22e1600bd11d#e5ec2e66d3aead34f7e3fa15909f22e1600bd11d"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -230,7 +230,7 @@ dependencies = [
 [[package]]
 name = "ark-relations"
 version = "0.1.0"
-source = "git+https://github.com/arkworks-rs/snark#8d9055d5397b510716ad2951ce1f18675aebe7c8"
+source = "git+https://github.com/arkworks-rs/snark//?rev=8d9055d5397b510716ad2951ce1f18675aebe7c8#8d9055d5397b510716ad2951ce1f18675aebe7c8"
 dependencies = [
  "ark-ff",
  "ark-std 0.1.0",
@@ -241,7 +241,7 @@ dependencies = [
 [[package]]
 name = "ark-serialize"
 version = "0.1.0"
-source = "git+https://github.com/arkworks-rs/algebra#8d76d181de0079b7e5a92f6e1133e7be635efdd3"
+source = "git+https://github.com/arkworks-rs/algebra//?rev=8d76d181de0079b7e5a92f6e1133e7be635efdd3#8d76d181de0079b7e5a92f6e1133e7be635efdd3"
 dependencies = [
  "ark-serialize-derive",
  "ark-std 0.1.0",
@@ -250,7 +250,7 @@ dependencies = [
 [[package]]
 name = "ark-serialize-derive"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/arkworks-rs/algebra#8d76d181de0079b7e5a92f6e1133e7be635efdd3"
+source = "git+https://github.com/arkworks-rs/algebra//?rev=8d76d181de0079b7e5a92f6e1133e7be635efdd3#8d76d181de0079b7e5a92f6e1133e7be635efdd3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -271,7 +271,7 @@ dependencies = [
 [[package]]
 name = "ark-std"
 version = "0.1.0"
-source = "git+https://github.com/arkworks-rs/utils#b37f1c8f73c94c5648b6dd310d02c3a81c8a37e9"
+source = "git+https://github.com/arkworks-rs/utils//?rev=b37f1c8f73c94c5648b6dd310d02c3a81c8a37e9#b37f1c8f73c94c5648b6dd310d02c3a81c8a37e9"
 dependencies = [
  "rand 0.7.3",
  "rayon",
@@ -280,7 +280,17 @@ dependencies = [
 [[package]]
 name = "ark-std"
 version = "0.3.0"
-source = "git+https://github.com/arkworks-rs/std#d0be44c030b35f369db6f9431903a283c077a1b9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.4",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/utils#d0be44c030b35f369db6f9431903a283c077a1b9"
 dependencies = [
  "colored",
  "num-traits",
@@ -319,7 +329,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "bench-utils"
 version = "0.1.0"
-source = "git+https://github.com/arkworks-rs/utils#b37f1c8f73c94c5648b6dd310d02c3a81c8a37e9"
+source = "git+https://github.com/arkworks-rs/utils//?rev=b37f1c8f73c94c5648b6dd310d02c3a81c8a37e9#b37f1c8f73c94c5648b6dd310d02c3a81c8a37e9"
 
 [[package]]
 name = "bitflags"
@@ -360,7 +370,8 @@ dependencies = [
  "ark-ed-on-bw6-761",
  "ark-ff",
  "ark-serialize",
- "ark-std 0.3.0",
+ "ark-std 0.1.0",
+ "ark-std 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2s_simd",
  "byteorder",
  "clap 3.0.1",
@@ -684,7 +695,8 @@ dependencies = [
  "ark-r1cs-std",
  "ark-relations",
  "ark-serialize",
- "ark-std 0.3.0",
+ "ark-std 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ark-std 0.3.0 (git+https://github.com/arkworks-rs/utils)",
  "blake2s_simd",
  "bls-crypto",
  "bls-gadgets",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,21 +9,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom 0.2.3",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -207,7 +209,7 @@ dependencies = [
  "ark-serialize",
  "ark-std 0.1.0",
  "derivative",
- "hashbrown",
+ "hashbrown 0.9.1",
  "rand 0.7.3",
  "rayon",
 ]
@@ -293,9 +295,9 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "atty"
@@ -339,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "blake2s_simd"
-version = "0.5.11"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
+checksum = "db539cc2b5f6003621f1cd9ef92d7ded8ea5232c7de0f9faa2de251cd98730d4"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -361,7 +363,7 @@ dependencies = [
  "ark-std 0.3.0",
  "blake2s_simd",
  "byteorder",
- "clap",
+ "clap 3.0.1",
  "criterion",
  "csv",
  "env_logger",
@@ -441,9 +443,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cast"
@@ -453,12 +455,6 @@ checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
 dependencies = [
  "rustc_version 0.2.3",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -485,13 +481,24 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term 0.11.0",
+ "bitflags",
+ "textwrap 0.11.0",
+ "unicode-width",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1121e32687f7f90b905d4775273305baa4f32cd418923e9b0fa726533221857"
+dependencies = [
  "atty",
  "bitflags",
+ "indexmap",
+ "os_str_bytes",
  "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "termcolor",
+ "textwrap 0.14.2",
 ]
 
 [[package]]
@@ -513,13 +520,13 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "criterion"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70daa7ceec6cf143990669a04c7df13391d55fb27bd4079d252fca774ba244d8"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.33.3",
  "criterion-plot",
  "csv",
  "itertools",
@@ -539,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
 dependencies = [
  "cast",
  "itertools",
@@ -553,7 +560,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -563,7 +570,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -574,7 +581,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -587,7 +594,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -603,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
@@ -651,9 +658,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "env_logger"
-version = "0.8.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",
@@ -705,7 +712,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -716,7 +723,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
 ]
@@ -733,7 +740,16 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 dependencies = [
- "ahash",
+ "ahash 0.4.7",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -747,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "humantime"
@@ -758,10 +774,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
-name = "itertools"
-version = "0.9.0"
+name = "indexmap"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -774,9 +800,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.46"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -795,20 +821,20 @@ checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "log"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
 ]
 
 [[package]]
 name = "lru"
-version = "0.6.5"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f374d42cdfc1d7dbf3d3dec28afab2eb97ffbf43a3234d795b5986dbf4b90ba"
+checksum = "274353858935c992b13c0ca408752e2121da852d07dec7ce5f108c77dfa14d1f"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -822,9 +848,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
@@ -877,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "oorandom"
@@ -892,6 +918,15 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "pest"
@@ -910,14 +945,30 @@ checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "plotters"
-version = "0.2.15"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d1685fbe7beba33de0330629da9d955ac75bd54f33d7b79f9a895590124f6bb"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
 dependencies = [
- "js-sys",
  "num-traits",
+ "plotters-backend",
+ "plotters-svg",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -1214,9 +1265,9 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -1226,9 +1277,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
-version = "1.0.58"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
+checksum = "6498a9efc342871f91cc2d0d694c674368b4ceb40f62b65a7a08c3792935e702"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1266,19 +1317,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.23"
+name = "textwrap"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+
+[[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1316,11 +1373,11 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.22"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1328,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.11"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
+checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1339,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.17"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
 ]
@@ -1373,7 +1430,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "chrono",
  "lazy_static",
  "matchers",
@@ -1414,10 +1471,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
+name = "version_check"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
@@ -1444,19 +1501,19 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.69"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.69"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1469,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.69"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1479,9 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.69"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1492,15 +1549,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.69"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "web-sys"
-version = "0.3.46"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,48 @@ opt-level = 3
 incremental = true
 debug-assertions = true
 debug = true
+
+
+### /!\ WARNING: fragile hack! /!\
+### This is using URL mangling to confuse the cargo resolver into resolving a patch to what it thinks is a 
+### different source, when it isn't. See https://github.com/rust-lang/cargo/issues/7497 for details.
+### The intent is to force the versioning of all the transitive dependencies of arkworks-based crates, 
+### despite them only relying on git dependencies. 
+###
+### This will break the moment the cargo resolver stops being confused by tail forward slashes, or the moment git stops 
+### resolving them correctly, whichever comes first. It's also very easy to create cycles in cargo's resolver with this.
+###
+### This is cursed, and a proper vendoring of those crates (or an upgrade of the groth16 circuit) should replace this.
+### 
+[patch."https://github.com/arkworks-rs/algebra"]
+ark-ec = { git = "https://github.com/arkworks-rs/algebra//", rev = "8d76d181de0079b7e5a92f6e1133e7be635efdd3" }
+ark-ff = { git = "https://github.com/arkworks-rs/algebra//", rev = "8d76d181de0079b7e5a92f6e1133e7be635efdd3" }
+ark-ff-asm = { git = "https://github.com/arkworks-rs/algebra//", rev = "8d76d181de0079b7e5a92f6e1133e7be635efdd3" }
+ark-ff-macros = { git = "https://github.com/arkworks-rs/algebra//", rev = "8d76d181de0079b7e5a92f6e1133e7be635efdd3" }
+ark-poly = { git = "https://github.com/arkworks-rs/algebra//", rev = "8d76d181de0079b7e5a92f6e1133e7be635efdd3" }
+ark-serialize = { git = "https://github.com/arkworks-rs/algebra//", rev = "8d76d181de0079b7e5a92f6e1133e7be635efdd3" }
+ark-serialize-derive = { git = "https://github.com/arkworks-rs/algebra//", rev = "8d76d181de0079b7e5a92f6e1133e7be635efdd3" }
+
+[patch."https://github.com/arkworks-rs/curves"]
+ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves//", rev = "6ed2450b5505de5d451f629bb6642e3977bf66e2" }
+ark-bw6-761 = { git = "https://github.com/arkworks-rs/curves//", rev = "6ed2450b5505de5d451f629bb6642e3977bf66e2" }
+ark-ed-on-bls12-377 = { git = "https://github.com/arkworks-rs/curves//", rev = "6ed2450b5505de5d451f629bb6642e3977bf66e2" }
+ark-ed-on-bw6-761 = { git = "https://github.com/arkworks-rs/curves//", rev = "6ed2450b5505de5d451f629bb6642e3977bf66e2" }
+ark-ed-on-cp6-782 = { git = "https://github.com/arkworks-rs/curves//", rev = "6ed2450b5505de5d451f629bb6642e3977bf66e2" }
+
+[patch."https://github.com/arkworks-rs/crypto-primitives"]
+ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives//", rev = "fde39ab764f00e28b2f292af3706a2654ea55edb" }
+
+[patch."https://github.com/arkworks-rs/groth16"]
+ark-groth16 = { git = "https://github.com/arkworks-rs/groth16//", rev = "d8acb2b2108023b2ad09974040b347b03bfe70b1" }
+
+[patch."https://github.com/arkworks-rs/r1cs-std"]
+ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std//", rev = "e5ec2e66d3aead34f7e3fa15909f22e1600bd11d" }
+
+[patch."https://github.com/arkworks-rs/snark"]
+ark-relations = { git = "https://github.com/arkworks-rs/snark//", rev = "8d9055d5397b510716ad2951ce1f18675aebe7c8" }
+
+[patch."https://github.com/arkworks-rs/utils"]
+ark-std = { git = "https://github.com/arkworks-rs/utils//", rev = "b37f1c8f73c94c5648b6dd310d02c3a81c8a37e9" }
+bench-utils = { git = "https://github.com/arkworks-rs/utils//", rev = "b37f1c8f73c94c5648b6dd310d02c3a81c8a37e9" }
+

--- a/crates/bls-crypto/Cargo.toml
+++ b/crates/bls-crypto/Cargo.toml
@@ -9,7 +9,9 @@ ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves" }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", features = [ "derive" ] }
 ark-ff = { git = "https://github.com/arkworks-rs/algebra", features = [ "std", "parallel"] }
 ark-ec = { git = "https://github.com/arkworks-rs/algebra", features = [ "std", "parallel"] }
-ark-std = { git = "https://github.com/arkworks-rs/std" }
+ark-std-recent = { version = "0.3", package = "ark-std" }
+ark-std = { git = "https://github.com/arkworks-rs/utils" }
+
 ark-ed-on-bw6-761 = { git = "https://github.com/arkworks-rs/curves" }
 ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives", branch = "main", features = ["parallel"] }
 

--- a/crates/bls-crypto/Cargo.toml
+++ b/crates/bls-crypto/Cargo.toml
@@ -15,20 +15,20 @@ ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitive
 
 # other deps
 rand = "0.7"
-byteorder = "1.4.2"
-hex = "0.4.2"
-clap = "2.33.0"
-log = "0.4.6"
-lru = "0.6.3"
-env_logger = "0.8.2"
-blake2s_simd = "0.5.8"
-csv = "1.1.5"
+byteorder = "1.4.3"
+hex = "0.4.3"
+clap = "3.0.1"
+log = "0.4.14"
+lru = "0.7.2"
+env_logger = "0.9.0"
+blake2s_simd = "1.0.0"
+csv = "1.1.6"
 rand_chacha = "0.2"
-thiserror = "1.0.23"
-once_cell = "1.3.1"
+thiserror = "1.0.30"
+once_cell = "1.9.0"
 
 [dev-dependencies]
-criterion = "0.3.1"
+criterion = "0.3.5"
 rand_xorshift = "0.2"
 
 [[example]]

--- a/crates/bls-crypto/examples/pop.rs
+++ b/crates/bls-crypto/examples/pop.rs
@@ -8,8 +8,8 @@ fn main() {
     let matches = App::new("BLS Proof of Possession")
         .about("Generates a proof of posession for the given private key")
         .arg(
-            Arg::with_name("key")
-                .short("k")
+            Arg::new("key")
+                .short('k')
                 .value_name("KEY")
                 .help("Sets the BLS private key")
                 .required(true),

--- a/crates/bls-crypto/examples/pop_csv.rs
+++ b/crates/bls-crypto/examples/pop_csv.rs
@@ -9,15 +9,15 @@ fn main() {
     let matches = App::new("BLS Proof of Possession test vectors")
         .about("Generates many proof of posession for random keys")
         .arg(
-            Arg::with_name("num")
-                .short("n")
+            Arg::new("num")
+                .short('n')
                 .value_name("NUM")
                 .help("Sets the number of test vectors")
                 .required(true),
         )
         .arg(
-            Arg::with_name("out")
-                .short("o")
+            Arg::new("out")
+                .short('o')
                 .value_name("OUT")
                 .help("Sets the output file path")
                 .required(true),

--- a/crates/bls-crypto/examples/simple_signature.rs
+++ b/crates/bls-crypto/examples/simple_signature.rs
@@ -11,8 +11,8 @@ fn main() {
     let matches = App::new("SimpleAggregatedSignature")
         .about("Show an example of a simple signature with a random key")
         .arg(
-            Arg::with_name("message")
-                .short("m")
+            Arg::new("message")
+                .short('m')
                 .value_name("MESSAGE")
                 .help("Sets the message to sign")
                 .required(true),

--- a/crates/bls-crypto/src/bls/batch.rs
+++ b/crates/bls-crypto/src/bls/batch.rs
@@ -89,10 +89,7 @@ impl Batch {
         hash_to_g1: &H,
     ) -> Result<(), BLSError> {
         for (pk, sig) in self.entries.iter() {
-            let result = pk.verify(&self.message, &self.extra_data, sig, hash_to_g1);
-            if result.is_err() {
-                return result;
-            }
+            pk.verify(&self.message, &self.extra_data, sig, hash_to_g1)?
         }
         Ok(())
     }

--- a/crates/bls-crypto/src/hash_to_curve/mod.rs
+++ b/crates/bls-crypto/src/hash_to_curve/mod.rs
@@ -281,7 +281,7 @@ mod compat_tests {
     };
     use ark_ff::{Field, FpParameters, FromBytes, PrimeField, SquareRootField, Zero};
     use ark_serialize::CanonicalSerialize;
-    use ark_std::{end_timer, start_timer};
+    use ark_std_recent::{end_timer, start_timer};
     use byteorder::WriteBytesExt;
     use log::trace;
     use rand::SeedableRng;

--- a/crates/bls-crypto/src/hash_to_curve/try_and_increment.rs
+++ b/crates/bls-crypto/src/hash_to_curve/try_and_increment.rs
@@ -1,4 +1,4 @@
-use ark_std::{end_timer, start_timer};
+use ark_std_recent::{end_timer, start_timer};
 use byteorder::WriteBytesExt;
 use log::trace;
 use std::marker::PhantomData;

--- a/crates/bls-crypto/src/hash_to_curve/try_and_increment_cip22.rs
+++ b/crates/bls-crypto/src/hash_to_curve/try_and_increment_cip22.rs
@@ -1,4 +1,4 @@
-use ark_std::{end_timer, start_timer};
+use ark_std_recent::{end_timer, start_timer};
 use byteorder::WriteBytesExt;
 use log::trace;
 use std::marker::PhantomData;

--- a/crates/bls-gadgets/Cargo.toml
+++ b/crates/bls-gadgets/Cargo.toml
@@ -19,13 +19,13 @@ ark-bw6-761 = { git = "https://github.com/arkworks-rs/curves" }
 
 # used only when exporting our test helpers to be used in the snark crate
 rand_xorshift = { version = "0.2", optional = true }
-rand = { version = "0.7" , optional = true }
-tracing = "0.1.13"
-tracing-subscriber = { version = "0.2" }
+rand = { version = "0.7", optional = true }
+tracing = "0.1.29"
+tracing-subscriber = "0.2"
 
 [dev-dependencies]
-rand_xorshift = { version = "0.2" }
-rand = { version = "0.7" }
+rand_xorshift = "0.2"
+rand = "0.7"
 ark-groth16 = { git = "https://github.com/arkworks-rs/groth16", features = [ "std", "parallel", "r1cs" ] }
 bls-crypto = { path = "../bls-crypto", default-features = false, features = ["test-helpers"] }
 

--- a/crates/bls-gadgets/src/hash_to_group.rs
+++ b/crates/bls-gadgets/src/hash_to_group.rs
@@ -222,8 +222,7 @@ pub fn hash_to_bits<F: PrimeField>(
             // convert hash result to LE bits
             let xof_bits_i = xof_result
                 .into_iter()
-                .map(|n| n.to_bits_le())
-                .flatten()
+                .flat_map(|n| n.to_bits_le())
                 .collect::<Vec<Boolean<F>>>();
             xof_bits.extend_from_slice(&xof_bits_i);
         }

--- a/crates/bls-snark-sys/Cargo.toml
+++ b/crates/bls-snark-sys/Cargo.toml
@@ -11,9 +11,9 @@ ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves" }
 ark-ff = { git = "https://github.com/arkworks-rs/algebra", features = [ "std", "parallel"] }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", features = [ "derive" ] }
 ark-ec = { git = "https://github.com/arkworks-rs/algebra", features = [ "std", "parallel"] }
-once_cell = "1.4.0"
+once_cell = "1.9.0"
 rand = "0.7"
-log = "0.4.8"
+log = "0.4.14"
 
 [lib]
 crate-type = ["lib", "staticlib"]
@@ -21,5 +21,5 @@ crate-type = ["lib", "staticlib"]
 [dev-dependencies]
 ark-groth16 = { git = "https://github.com/arkworks-rs/groth16", features = [ "std", "parallel", "r1cs" ] }
 ark-relations = { git = "https://github.com/arkworks-rs/snark", features = [ "std" ] }
-hex = "0.4.2"
+hex = "0.4.3"
 ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std", default-features = false, features = ["std", "parallel"] }

--- a/crates/epoch-snark/Cargo.toml
+++ b/crates/epoch-snark/Cargo.toml
@@ -19,7 +19,8 @@ ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std", default-featur
 ark-relations = { git = "https://github.com/arkworks-rs/snark", features = [ "std" ] }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra", features = [ "derive" ] }
 ark-groth16 = { git = "https://github.com/arkworks-rs/groth16", features = [ "std", "parallel", "r1cs" ] }
-ark-std = { git = "https://github.com/arkworks-rs/std" }
+ark-std-recent = { version = "0.3", package = "ark-std" }
+ark-std = { git = "https://github.com/arkworks-rs/utils" }
 
 rand = "0.7"
 byteorder = "1.4.3"

--- a/crates/epoch-snark/Cargo.toml
+++ b/crates/epoch-snark/Cargo.toml
@@ -22,17 +22,17 @@ ark-groth16 = { git = "https://github.com/arkworks-rs/groth16", features = [ "st
 ark-std = { git = "https://github.com/arkworks-rs/std" }
 
 rand = "0.7"
-byteorder = "1.3.2"
-blake2s_simd = "0.5.8"
-thiserror = "1.0.11"
-tracing-subscriber = "0.2.3"
-tracing = "0.1.13"
+byteorder = "1.4.3"
+blake2s_simd = "1.0.0"
+thiserror = "1.0.30"
+tracing-subscriber = "0.2"
+tracing = "0.1.29"
 
 [dev-dependencies]
-rand_xorshift = { version = "0.2" }
+rand_xorshift = "0.2"
 bls-gadgets = { path = "../bls-gadgets", default-features = false, features = ["test-helpers"] }
 bls-crypto = { path = "../bls-crypto", default-features = false, features = ["test-helpers"] }
-hex = "0.4.2"
+hex = "0.4.3"
 
 [features]
 default = ["compat"]

--- a/crates/epoch-snark/examples/proof.rs
+++ b/crates/epoch-snark/examples/proof.rs
@@ -10,7 +10,7 @@ use tracing_subscriber::{
     fmt::{time::ChronoUtc, Subscriber},
 };
 
-use ark_std::{end_timer, start_timer};
+use ark_std_recent::{end_timer, start_timer};
 
 fn main() {
     Subscriber::builder()

--- a/crates/epoch-snark/src/api/prover.rs
+++ b/crates/epoch-snark/src/api/prover.rs
@@ -36,10 +36,7 @@ pub fn prove(
     let span = span!(Level::TRACE, "prove");
     let _enter = span.enter();
 
-    let mut epochs = transitions
-        .iter()
-        .map(to_update)
-        .collect::<Vec<_>>();
+    let mut epochs = transitions.iter().map(to_update).collect::<Vec<_>>();
 
     let num_epochs = epochs.len();
     if num_epochs < max_transitions {

--- a/crates/epoch-snark/src/api/prover.rs
+++ b/crates/epoch-snark/src/api/prover.rs
@@ -38,7 +38,7 @@ pub fn prove(
 
     let mut epochs = transitions
         .iter()
-        .map(|transition| to_update(transition))
+        .map(to_update)
         .collect::<Vec<_>>();
 
     let num_epochs = epochs.len();
@@ -55,11 +55,11 @@ pub fn prove(
 
     // Generate a helping proof if a Proving Key for the HashToBits
     // circuit was provided
-    let hash_helper = if let Some(ref params) = parameters.hash_to_bits {
-        Some(generate_hash_helper(params, transitions)?)
-    } else {
-        None
-    };
+    let hash_helper = parameters
+        .hash_to_bits
+        .as_ref()
+        .map(|params| generate_hash_helper(params, transitions))
+        .transpose()?;
 
     // Generate the BLS proof
     let asig = Signature::aggregate(transitions.iter().map(|epoch| &epoch.aggregate_signature));

--- a/crates/epoch-snark/src/encoding.rs
+++ b/crates/epoch-snark/src/encoding.rs
@@ -51,8 +51,7 @@ pub(crate) fn encode_u8(num: u8) -> Result<Vec<bool>, EncodingError> {
     let bytes = vec![num];
     let bits = bytes
         .into_iter()
-        .map(|x| (0..8).map(move |i| (((x as u8) & u8::pow(2, i)) >> i) == 1))
-        .flatten()
+        .flat_map(|x| (0..8).map(move |i| (((x as u8) & u8::pow(2, i)) >> i) == 1))
         .collect::<Vec<_>>();
     Ok(bits)
 }
@@ -63,8 +62,7 @@ pub(crate) fn encode_u16(num: u16) -> Result<Vec<bool>, EncodingError> {
     bytes.write_u16::<LittleEndian>(num)?;
     let bits = bytes
         .into_iter()
-        .map(|x| (0..8).map(move |i| (((x as u16) & u16::pow(2, i)) >> i) == 1))
-        .flatten()
+        .flat_map(|x| (0..8).map(move |i| (((x as u16) & u16::pow(2, i)) >> i) == 1))
         .collect::<Vec<_>>();
     Ok(bits)
 }
@@ -75,8 +73,7 @@ pub(crate) fn encode_u32(num: u32) -> Result<Vec<bool>, EncodingError> {
     bytes.write_u32::<LittleEndian>(num)?;
     let bits = bytes
         .into_iter()
-        .map(|x| (0..8).map(move |i| (((x as u32) & u32::pow(2, i)) >> i) == 1))
-        .flatten()
+        .flat_map(|x| (0..8).map(move |i| (((x as u32) & u32::pow(2, i)) >> i) == 1))
         .collect::<Vec<_>>();
     Ok(bits)
 }

--- a/crates/epoch-snark/src/gadgets/epoch_bits.rs
+++ b/crates/epoch-snark/src/gadgets/epoch_bits.rs
@@ -84,8 +84,7 @@ impl EpochBits {
                 evaluate_blake2s_with_parameters(&message, &blake2s_parameters.parameters())?;
             let xof_bits_i = xof_result
                 .into_iter()
-                .map(|n| n.to_bits_le())
-                .flatten()
+                .flat_map(|n| n.to_bits_le())
                 .collect::<Vec<Bool>>();
             xof_bits.extend_from_slice(&xof_bits_i);
         }
@@ -172,8 +171,7 @@ mod tests {
 
         let both_blake_bits = [first_bytes.clone(), last_bytes.clone()]
             .iter()
-            .map(|b| hash_to_bits(b))
-            .flatten()
+            .flat_map(|b| hash_to_bits(b))
             .collect::<Vec<bool>>();
 
         let cs = ConstraintSystem::<Fr>::new_ref();


### PR DESCRIPTION
### Description

This is an alternative to #229 which use a hack to force a rewrite of all[^1] arkworks dependencies to what they currently are in the Cargo.lock. This improves on #226 in that it pins everything, including packages such as `bench-utils`, which no longer exist otherwise than transitively.

See the last commit for a scary message on the load-bearing workspace patch section.

[^1]: all but one, as there is one use of ark-std for telemetry that requires a newer ark-std, and is left unconstrainted through package aliasing.

### Tested, etc ..

Please see #229 

### Related issues

- Fixes #228

/cc @nategraf @gtank 